### PR TITLE
Enhance control deck HUD and motion lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 [![Roadmap](https://img.shields.io/badge/📋_PROJECT_ROADMAP-ffcc00?style=for-the-badge)](https://spiralcloudomega.github.io/DevTeam6/roadmap)
 [![Node Graph](https://img.shields.io/badge/⚡_NODE_GRAPH-00f0ff?style=for-the-badge)](https://spiralcloudomega.github.io/DevTeam6/node-graph)
 [![Videos](https://img.shields.io/badge/🎬_VIDEO_STORIES-ff0066?style=for-the-badge)](https://spiralcloudomega.github.io/DevTeam6/videos)
+[![Repomind](https://img.shields.io/badge/🧠_REPOMIND_WORKSTATION-00ff88?style=for-the-badge)](https://spiralcloudomega.github.io/DevTeam6/repomind)
+[![Control Deck](https://img.shields.io/badge/🛰️_CONTROL_DECK-7b2fff?style=for-the-badge)](https://spiralcloudomega.github.io/DevTeam6/control-deck)
 
 ---
 
@@ -65,6 +67,12 @@
 <a href="https://spiralcloudomega.github.io/DevTeam6/onboarding">
   <img src="https://img.shields.io/badge/🚀_ONBOARDING_WIZARD-00ff88?style=for-the-badge&logoColor=white" alt="Onboarding Wizard" />
 </a>
+<a href="https://spiralcloudomega.github.io/DevTeam6/repomind">
+  <img src="https://img.shields.io/badge/🧠_REPOMIND_WORKSTATION-00ff88?style=for-the-badge&logoColor=white" alt="Repomind Workstation" />
+</a>
+<a href="https://spiralcloudomega.github.io/DevTeam6/control-deck">
+  <img src="https://img.shields.io/badge/🛰️_CONTROL_DECK-7b2fff?style=for-the-badge&logoColor=white" alt="Control Deck" />
+</a>
 
 *Experience DevTeam6 in immersive 3D • Navigate the Semantic Knowledge Hub • Generate UI with natural language • Explore Node Graph workflows • Watch video tutorials • Track contributions on the Leaderboard*
 
@@ -74,11 +82,13 @@
 | **Semantic Knowledge Hub** | AI-first knowledge graph with semantic search and completeness meters | NEW |
 | **Immersive Landing** | GSAP scroll-animated landing page with parallax effects | Live |
 | **GenUI Playground** | AI-powered component generator using natural language prompts | Live |
-| **Node Graph Editor** | n8n-style interactive workflow visualization with clickable nodes | Live |
+| **Node Graph Editor** | n8n-style interactive workflow visualization with clickable nodes, Tron halos, MCP widgets, and a Path Playbook route finder | Live |
 | **Video Storytelling** | Chapter-based video guides with interactive timeline navigation | Live |
 | **Gamification Dashboard** | Contributor leaderboard, achievements, and statistics | Live |
 | **Project Roadmap** | Interactive board/timeline/list view of project progress | Live |
 | **Onboarding Wizard** | Step-by-step contributor guide with progress tracking | Live |
+| **Repomind Workstation** | In-repo digital workstation with neon ribbons, UX Motion Lab, widget shelf, control center, pipelines, persona blender + YouTube player | NEW |
+| **Control Deck** | Static digital workstation control deck with docked panels, mission briefings/preview, status HUD, command palette, UX Motion Lab, macros, and low-power toggle | NEW |
 
 ---
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -730,6 +730,10 @@ function App() {
       '6': '/DevTeam6/gamification',
       '7': '/DevTeam6/roadmap',
       '8': '/DevTeam6/onboarding',
+      '9': '/DevTeam6/repomind',
+      '0': '/DevTeam6/repopilot',
+      c: '/DevTeam6/control-deck',
+      C: '/DevTeam6/control-deck'
     }
     if (shortcuts[e.key]) {
       window.location.assign(shortcuts[e.key])
@@ -803,8 +807,14 @@ function App() {
           <a href="/DevTeam6/onboarding" className="btn secondary" data-shortcut="8">
             🚀 Get Started
           </a>
-          <a href="/DevTeam6/repopilot" className="btn primary" data-shortcut="9">
+          <a href="/DevTeam6/repomind" className="btn primary" data-shortcut="9">
+            🧠 Repomind Workstation
+          </a>
+          <a href="/DevTeam6/repopilot" className="btn primary" data-shortcut="0">
             🧠 AI Co-Pilot
+          </a>
+          <a href="/DevTeam6/control-deck" className="btn secondary" data-shortcut="C">
+            🛰️ Control Deck
           </a>
         </div>
         
@@ -824,6 +834,9 @@ function App() {
                 <div className="shortcut-item"><kbd>6</kbd> Leaderboard</div>
                 <div className="shortcut-item"><kbd>7</kbd> Roadmap</div>
                 <div className="shortcut-item"><kbd>8</kbd> Onboarding</div>
+                <div className="shortcut-item"><kbd>9</kbd> Repomind Workstation</div>
+                <div className="shortcut-item"><kbd>0</kbd> AI Co-Pilot</div>
+                <div className="shortcut-item"><kbd>C</kbd> Control Deck</div>
               </div>
               <p className="shortcuts-footer">Click anywhere to close</p>
             </div>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -138,6 +138,29 @@ html, body, #root {
   }
 }
 
+.repomind-ribbon {
+  position: absolute;
+  width: 60%;
+  height: 60%;
+  filter: blur(60px);
+  opacity: 0.35;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 50%, rgba(0, 240, 255, 0.35), rgba(0, 0, 0, 0));
+  animation: holoDrift 22s linear infinite, pulseSweep 14s ease-in-out infinite;
+}
+
+.repomind-ribbon--left {
+  top: -10%;
+  left: -20%;
+}
+
+.repomind-ribbon--right {
+  bottom: -20%;
+  right: -10%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 0, 255, 0.28), rgba(0, 0, 0, 0));
+  animation-direction: reverse, normal;
+}
+
 @keyframes borderGlow {
   0%, 100% {
     box-shadow: 0 0 5px currentColor, inset 0 0 5px transparent;
@@ -1096,4 +1119,485 @@ html, body, #root {
 .btn[data-shortcut]:hover::after {
   opacity: 1;
   transform: scale(1);
+}
+
+@keyframes holoDrift {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+  50% {
+    transform: translate3d(20%, -10%, 0) rotate(12deg);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+}
+
+@keyframes pulseSweep {
+  0%, 100% {
+    opacity: 0.24;
+    filter: blur(80px);
+  }
+  50% {
+    opacity: 0.6;
+    filter: blur(60px);
+  }
+}
+
+/* Control Deck */
+.control-deck {
+  position: relative;
+  min-height: 100vh;
+  padding: 28px;
+  color: #e8f9ff;
+  overflow: auto;
+  background: radial-gradient(circle at 20% 20%, rgba(0, 240, 255, 0.12), transparent 32%),
+    radial-gradient(circle at 80% 30%, rgba(255, 0, 255, 0.1), transparent 35%),
+    linear-gradient(135deg, #050510 0%, #0d0d1c 50%, #100820 100%);
+}
+
+.control-deck__background {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.control-deck__grid {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  background-size: 42px 42px;
+  mask-image: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.55), transparent 70%);
+}
+
+.control-deck__ribbon {
+  position: absolute;
+  width: 120%;
+  height: 320px;
+  filter: blur(60px);
+  opacity: 0.35;
+  transform: rotate(-6deg);
+}
+
+.control-deck__ribbon--a {
+  top: -80px;
+  left: -10%;
+  background: linear-gradient(90deg, rgba(0, 240, 255, 0.4), rgba(255, 0, 255, 0.15));
+}
+
+.control-deck__ribbon--b {
+  bottom: -120px;
+  right: -10%;
+  background: linear-gradient(90deg, rgba(255, 0, 255, 0.35), rgba(0, 240, 255, 0.18));
+  transform: rotate(4deg);
+}
+
+.control-deck__header {
+  position: relative;
+  z-index: 1;
+  border: 1px solid rgba(0, 240, 255, 0.35);
+  background: rgba(8, 10, 26, 0.9);
+  border-radius: 18px;
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.control-deck__eyebrow {
+  margin: 0;
+  color: #00f0ff;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.control-deck__subtitle {
+  margin: 6px 0 12px;
+  color: #9ddff6;
+}
+
+.control-deck__theme-toggle {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.control-deck__quick-meta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  align-items: center;
+  text-align: right;
+}
+
+.meta-label {
+  margin: 0;
+  color: #9ddff6;
+  font-size: 12px;
+}
+
+.meta-value {
+  margin: 2px 0 0;
+  font-weight: 700;
+}
+
+.control-deck__body {
+  position: relative;
+  z-index: 1;
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 14px;
+}
+
+.control-deck__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dock {
+  background: rgba(10, 12, 28, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 14px;
+  display: flex;
+  gap: 12px;
+  color: #e8f9ff;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dock:hover,
+.dock:focus-visible {
+  border-color: #00f0ff;
+  box-shadow: 0 10px 30px rgba(0, 240, 255, 0.16);
+}
+
+.dock--active {
+  border-color: #ff00ff;
+  box-shadow: 0 10px 30px rgba(255, 0, 255, 0.16);
+}
+
+.dock__icon {
+  font-size: 22px;
+}
+
+.dock__title {
+  margin: 0;
+  font-weight: 700;
+}
+
+.dock__desc {
+  margin: 2px 0 0;
+  color: #9ddff6;
+}
+
+.control-deck__main {
+  background: rgba(8, 10, 26, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 16px;
+  backdrop-filter: blur(10px);
+}
+
+.control-deck__panel + .control-deck__panel {
+  margin-top: 12px;
+}
+
+.panel__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel__header p {
+  margin: 4px 0 0;
+  color: #9ddff6;
+}
+
+.panel__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.panel__grid--two {
+  grid-template-columns: 1fr 1fr;
+}
+
+.panel__card {
+  background: linear-gradient(135deg, rgba(0, 240, 255, 0.08), rgba(255, 0, 255, 0.08));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 14px;
+  min-height: 150px;
+}
+
+.panel__label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: #00f0ff;
+}
+
+.panel__list {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  color: #d3e8ff;
+  display: grid;
+  gap: 6px;
+}
+
+.panel__note {
+  margin: 12px 0 0;
+  color: #9ddff6;
+  font-size: 12px;
+}
+
+.minimap {
+  background: rgba(5, 8, 18, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  position: relative;
+}
+
+.minimap__node {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #00f0ff, #ff00ff);
+  opacity: 0.4;
+}
+
+.minimap__path {
+  position: absolute;
+  inset: 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.4);
+  border-radius: 12px;
+}
+
+.telemetry {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.playlist {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.playlist__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 8, 18, 0.8);
+  color: #e8f9ff;
+  cursor: pointer;
+  text-align: left;
+}
+
+.playlist__item--active {
+  border-color: #00f0ff;
+  box-shadow: 0 10px 25px rgba(0, 240, 255, 0.2);
+}
+
+.playlist__title {
+  margin: 0;
+  font-weight: 700;
+}
+
+.playlist__meta {
+  margin: 2px 0 0;
+  color: #9ddff6;
+}
+
+.player {
+  position: relative;
+  padding-top: 56.25%;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #000;
+}
+
+.player iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.player--error {
+  display: grid;
+  place-items: center;
+  height: 240px;
+  color: #ff6600;
+  font-weight: 700;
+}
+
+.agent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.agent__name {
+  margin: 0;
+  font-weight: 700;
+}
+
+.agent__role {
+  margin: 2px 0 0;
+  color: #9ddff6;
+}
+
+.macros {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.macro-preview {
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  background: rgba(0, 240, 255, 0.05);
+}
+
+.macro-preview__text {
+  margin: 6px 0 0;
+  color: #e8f9ff;
+}
+
+.quickstarts {
+  display: grid;
+  gap: 10px;
+}
+
+.quickstart {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 8, 18, 0.85);
+}
+
+.quickstart__title {
+  margin: 0;
+  font-weight: 700;
+}
+
+.quickstart__meta {
+  margin: 4px 0;
+  color: #9ddff6;
+}
+
+.quickstart__cta {
+  color: #00f0ff;
+  font-weight: 700;
+}
+
+.highlighted {
+  border-left: 3px solid #ff00ff;
+  padding-left: 8px;
+}
+
+.linkish {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.command {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: grid;
+  place-items: center;
+  z-index: 10;
+  padding: 16px;
+}
+
+.command__content {
+  background: rgba(5, 8, 18, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  width: min(720px, 90vw);
+  padding: 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.command__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #9ddff6;
+}
+
+.command__hint {
+  font-size: 12px;
+}
+
+.command__actions {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.command__item {
+  width: 100%;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 10, 26, 0.8);
+  color: #e8f9ff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.command__item--active {
+  border-color: #00f0ff;
+  box-shadow: 0 10px 25px rgba(0, 240, 255, 0.18);
+}
+
+.theme-quantum .control-deck__header,
+.theme-noir .control-deck__header,
+.theme-tron .control-deck__header {
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.pill {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(5, 8, 18, 0.7);
+  color: #e8f9ff;
+  cursor: pointer;
+}
+
+.pill--active {
+  border-color: #00f0ff;
+  box-shadow: 0 10px 22px rgba(0, 240, 255, 0.2);
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -11,6 +11,8 @@ import NodeGraphEditor from './pages/NodeGraphEditor'
 import VideoStorytelling from './pages/VideoStorytelling'
 import SemanticKnowledgeHub from './pages/SemanticKnowledgeHub'
 import RepoPilot from './pages/RepoPilot'
+import Repomind from './pages/Repomind'
+import ControlDeck from './pages/ControlDeck'
 import './index.css'
 
 // Handle SPA redirect from 404.html
@@ -47,6 +49,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <Route path="/videos" element={<VideoStorytelling />} />
         <Route path="/knowledge-hub" element={<SemanticKnowledgeHub />} />
         <Route path="/repopilot" element={<RepoPilot />} />
+        <Route path="/repomind" element={<Repomind />} />
+        <Route path="/control-deck" element={<ControlDeck />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,

--- a/app/src/pages/ControlDeck.tsx
+++ b/app/src/pages/ControlDeck.tsx
@@ -1,0 +1,555 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getLoadStatus, sanitizeEmbedUrl } from '../utils/controlDeck'
+
+interface Panel {
+  id: string
+  title: string
+  description: string
+  icon: string
+}
+
+interface Agent {
+  name: string
+  role: string
+  status: 'online' | 'standby'
+  focus: string
+}
+
+interface PlaylistItem {
+  title: string
+  url: string
+  chapter: string
+}
+
+const panels: Panel[] = [
+  { id: 'graph', title: 'Graph Deck', description: 'n8n-style clusters with path sim.', icon: '🛰️' },
+  { id: 'video', title: 'Mission Video Hub', description: 'Chapters + embedded briefings.', icon: '🎬' },
+  { id: 'agents', title: 'Agent Roster', description: 'Persona macros + background tasks.', icon: '🤖' },
+  { id: 'motion', title: 'UX Motion Lab', description: 'Glows, ribbons, and layout anchors.', icon: '🌀' },
+  { id: 'docs', title: 'Guidance Rail', description: 'Quick-start cards + shortcuts.', icon: '📜' }
+]
+
+const themes = [
+  { id: 'tron', label: 'Tron', primary: '#00f0ff', secondary: '#ff00ff' },
+  { id: 'quantum', label: 'Quantum', primary: '#7b2fff', secondary: '#00ff88' },
+  { id: 'noir', label: 'Noir Grid', primary: '#9ddff6', secondary: '#ffaa44' }
+]
+
+const playlist: PlaylistItem[] = [
+  { title: 'Control Deck Tour', url: 'https://www.youtube.com/watch?v=tpe_Y6h6BfM', chapter: '00:00 - Overview' },
+  { title: 'Graph Automation', url: 'https://www.youtube.com/watch?v=VdQkYJ_Rp-k', chapter: '02:10 - Path routing' },
+  { title: 'Repomind Personas', url: 'https://www.youtube.com/watch?v=6Dh-RL__uN4', chapter: '04:35 - Macro builder' }
+]
+
+const agentRoster: Agent[] = [
+  { name: 'Repomind Prime', role: 'Narrator', status: 'online', focus: 'Story + safety rails' },
+  { name: 'Ops Drive', role: 'Automation', status: 'online', focus: 'Path sim + telemetry' },
+  { name: 'Design Pulse', role: 'UX motion', status: 'standby', focus: 'Glows, ribbons, low-power' },
+  { name: 'Guardian', role: 'Security', status: 'standby', focus: 'Sanitize embeds + ARIA' }
+]
+
+const quickStarts = [
+  { title: 'Build', detail: 'pnpm install && pnpm dev', cta: 'Open build docs' },
+  { title: 'Test', detail: 'npm test -- --watch=false', cta: 'View QA checklist' },
+  { title: 'Deploy', detail: 'GitHub Pages /DevTeam6', cta: 'See deployment notes' }
+]
+
+const macroPresets = [
+  { label: 'Drive-Through', text: 'Summarize repo + surface live pages with shortcuts.' },
+  { label: 'Security Sweep', text: 'List hardening steps, 0 secrets, offline defaults.' },
+  { label: 'Design Glow', text: 'Suggest neon-friendly spacing + reduced-motion variant.' }
+]
+
+const actions = [
+  'Open Repomind with preset video',
+  'Toggle low-power mode (reduced particles)',
+  'Jump to Node Graph Path Playbook',
+  'Show keyboard shortcut overlay',
+  'Switch theme to Quantum',
+  'Open UX Motion Lab presets'
+]
+
+const motionTracks = [
+  { title: 'Tron Bloom', detail: 'Ribbon sweeps + neon particle halos', density: 'High motion' },
+  { title: 'Vector Drift', detail: 'Slow parallax grid with depth haze', density: 'Calm' },
+  { title: 'Pulse Trails', detail: 'Glow pulses mapped to macro queue', density: 'Reactive' }
+]
+
+const widgetShelf = [
+  { title: 'Dock Anchors', detail: 'Pinned nav pills for clusters', status: 'Ready' },
+  { title: 'Halo Widgets', detail: 'Status beacons for load + theme', status: 'Live' },
+  { title: 'Telemetry Tiles', detail: 'FPS + glow load HUD with tone', status: 'Synced' }
+]
+
+const missionBriefs: PlaylistItem[] = [
+  { title: 'First-Run Tour', url: 'https://www.youtube.com/watch?v=tpe_Y6h6BfM&t=23s', chapter: '00:23 - Docking intro' },
+  { title: 'Automation Preview', url: 'https://www.youtube.com/watch?v=VdQkYJ_Rp-k&t=64s', chapter: '01:04 - Path simulator' },
+  { title: 'Repomind Sync', url: 'https://www.youtube.com/watch?v=6Dh-RL__uN4&t=90s', chapter: '01:30 - Macro queues' }
+]
+
+export default function ControlDeck() {
+  const [activeTheme, setActiveTheme] = useState('tron')
+  const [activePanel, setActivePanel] = useState('graph')
+  const [commandOpen, setCommandOpen] = useState(false)
+  const [lowPower, setLowPower] = useState(false)
+  const [activeVideo, setActiveVideo] = useState(playlist[0])
+  const [selectedMacro, setSelectedMacro] = useState(macroPresets[0])
+  const [focusedAction, setFocusedAction] = useState(actions[0])
+  const [activeBriefing, setActiveBriefing] = useState(missionBriefs[0])
+
+  const theme = themes.find(t => t.id === activeTheme) ?? themes[0]
+  const embedUrl = useMemo(() => sanitizeEmbedUrl(activeVideo.url), [activeVideo.url])
+  const briefingEmbed = useMemo(() => sanitizeEmbedUrl(activeBriefing.url), [activeBriefing.url])
+  const fps = lowPower ? 60 : 144
+  const glowLoad = lowPower ? 0.32 : 0.68
+  const loadStatus = useMemo(() => getLoadStatus(fps, glowLoad), [fps, glowLoad])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'p' && (event.metaKey || event.ctrlKey || event.shiftKey)) {
+        event.preventDefault()
+        setCommandOpen(prev => !prev)
+      }
+      if (event.key === 'Escape' && commandOpen) {
+        setCommandOpen(false)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [commandOpen])
+
+  const renderHud = () => (
+    <section
+      className="control-deck__quick-meta"
+      aria-label="Workstation status HUD"
+      style={{ marginTop: '10px' }}
+    >
+      <div>
+        <p className="meta-label">Load Status</p>
+        <p className="meta-value">{loadStatus.label}</p>
+        <p className="panel__note">{loadStatus.description}</p>
+      </div>
+      <div>
+        <p className="meta-label">Theme Blend</p>
+        <p className="meta-value">{theme.label}</p>
+        <p className="panel__note">Primary {theme.primary}</p>
+      </div>
+      <div>
+        <p className="meta-label">Power Mode</p>
+        <p className="meta-value">{lowPower ? 'Low power' : 'Full glow'}</p>
+        <p className="panel__note">{lowPower ? 'Particles capped for laptops' : 'Max ribbons and stars'}</p>
+      </div>
+    </section>
+  )
+
+  const renderHeader = () => (
+    <header
+      className="control-deck__header"
+      style={{
+        borderColor: theme.primary,
+        boxShadow: `0 12px 42px rgba(0,0,0,0.45), 0 0 20px ${theme.primary}44`
+      }}
+    >
+      <div>
+        <p className="control-deck__eyebrow">OMEGA TOOL KIT • GITFATHER CONTROL DECK</p>
+        <h1>Static Digital Workstation</h1>
+        <p className="control-deck__subtitle">
+          Docked panels, command palette, and Tron-inspired ribbons to navigate the repo without leaving the page.
+        </p>
+        <div className="control-deck__theme-toggle" role="group" aria-label="Theme selector">
+          {themes.map(option => (
+            <button
+              key={option.id}
+              className={`pill ${option.id === activeTheme ? 'pill--active' : ''}`}
+              onClick={() => setActiveTheme(option.id)}
+              onKeyDown={e => e.key === 'Enter' && setActiveTheme(option.id)}
+              style={{ borderColor: option.primary, color: option.primary }}
+            >
+              {option.label}
+            </button>
+          ))}
+          <button
+            className={`pill ${lowPower ? 'pill--active' : ''}`}
+            onClick={() => setLowPower(prev => !prev)}
+            onKeyDown={e => e.key === 'Enter' && setLowPower(prev => !prev)}
+            aria-pressed={lowPower}
+          >
+            {lowPower ? 'Low Power: On' : 'Low Power: Off'}
+          </button>
+        </div>
+      </div>
+      <div className="control-deck__quick-meta" aria-label="Panel stats">
+        <div>
+          <p className="meta-label">Panels</p>
+          <p className="meta-value">5 docked</p>
+        </div>
+        <div>
+          <p className="meta-label">Command Palette</p>
+          <p className="meta-value">⇧⌘P / ⇧Ctrl+P</p>
+        </div>
+        <div>
+          <p className="meta-label">Theme</p>
+          <p className="meta-value">{theme.label}</p>
+        </div>
+      </div>
+    </header>
+  )
+
+  const renderNav = () => (
+    <nav className="control-deck__nav" aria-label="Dock navigation">
+      {panels.map(panel => (
+        <button
+          key={panel.id}
+          className={`dock ${panel.id === activePanel ? 'dock--active' : ''}`}
+          onClick={() => setActivePanel(panel.id)}
+          onKeyDown={e => e.key === 'Enter' && setActivePanel(panel.id)}
+          aria-pressed={panel.id === activePanel}
+        >
+          <span className="dock__icon" aria-hidden>
+            {panel.icon}
+          </span>
+          <div className="dock__content">
+            <p className="dock__title">{panel.title}</p>
+            <p className="dock__desc">{panel.description}</p>
+          </div>
+        </button>
+      ))}
+    </nav>
+  )
+
+  const renderGraphPanel = () => (
+    <section className="control-deck__panel">
+      <div className="panel__header">
+        <h2>Graph Deck</h2>
+        <p>Mind-map and automation presets with quick jump edges.</p>
+      </div>
+      <div className="panel__grid">
+        <div className="panel__card">
+          <p className="panel__label">Presets</p>
+          <ul className="panel__list">
+            <li>Knowledge Mind Map • clusters + halos</li>
+            <li>Automation Brain • signals → delivery</li>
+            <li>Path Playbook • start/target highlighting</li>
+          </ul>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Mini-map</p>
+          <div className="minimap" aria-label="Graph mini map">
+            {[...Array(9)].map((_, idx) => (
+              <span key={idx} className="minimap__node" aria-hidden />
+            ))}
+            <span className="minimap__path" aria-hidden />
+          </div>
+          <p className="panel__note">Scaled snapshot to keep orientation.</p>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Telemetry</p>
+          <div className="telemetry">
+            <div>
+              <p className="meta-label">FPS</p>
+              <p className="meta-value">{lowPower ? '60 capped' : '144 uncapped'}</p>
+            </div>
+            <div>
+              <p className="meta-label">Glow Health</p>
+              <p className="meta-value">Stable</p>
+            </div>
+            <div>
+              <p className="meta-label">Hops</p>
+              <p className="meta-value">6 max</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+
+  const renderVideoPanel = () => (
+    <section className="control-deck__panel">
+      <div className="panel__header">
+        <h2>Mission Video Hub</h2>
+        <p>Embedded playlists with sanitized links and chapter hints.</p>
+      </div>
+      <div className="panel__grid">
+        <div className="panel__card">
+          <p className="panel__label">Playlist</p>
+          <div className="playlist" role="list">
+            {playlist.map(item => (
+              <button
+                key={item.url}
+                role="listitem"
+                className={`playlist__item ${item.url === activeVideo.url ? 'playlist__item--active' : ''}`}
+                onClick={() => setActiveVideo(item)}
+                onKeyDown={e => e.key === 'Enter' && setActiveVideo(item)}
+                aria-pressed={item.url === activeVideo.url}
+              >
+                <div>
+                  <p className="playlist__title">{item.title}</p>
+                  <p className="playlist__meta">{item.chapter}</p>
+                </div>
+                <span aria-hidden>▶</span>
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Embedded Player</p>
+          {embedUrl ? (
+            <div className="player">
+              <iframe
+                title={activeVideo.title}
+                src={embedUrl}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          ) : (
+            <div className="player player--error">Invalid video URL — only YouTube hosts are allowed.</div>
+          )}
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Mission Briefings</p>
+          <div className="macros">
+            {missionBriefs.map(briefing => (
+              <button
+                key={briefing.url}
+                className={`playlist__item ${briefing.title === activeBriefing.title ? 'playlist__item--active' : ''}`}
+                onClick={() => setActiveBriefing(briefing)}
+                onKeyDown={e => e.key === 'Enter' && setActiveBriefing(briefing)}
+                aria-pressed={briefing.title === activeBriefing.title}
+              >
+                <div>
+                  <p className="playlist__title">{briefing.title}</p>
+                  <p className="playlist__meta">{briefing.chapter}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+          <p className="panel__note">Briefings mirror the YouTube playlist with safe embeds.</p>
+        </div>
+      </div>
+      <div className="panel__grid panel__grid--two">
+        <div className="panel__card">
+          <p className="panel__label">Briefing Preview</p>
+          {briefingEmbed ? (
+            <div className="player">
+              <iframe
+                title={activeBriefing.title}
+                src={briefingEmbed}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          ) : (
+            <div className="player player--error">Invalid briefing link — only YouTube hosts are allowed.</div>
+          )}
+          <p className="panel__note">{activeBriefing.chapter}</p>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Story cues</p>
+          <ul className="panel__list">
+            <li>Use the briefing preview for in-repo tours.</li>
+            <li>Pair with macros to pre-stage Repomind prompts.</li>
+            <li>Low-power mode keeps iframe effects lighter.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+
+  const renderAgentsPanel = () => (
+    <section className="control-deck__panel">
+      <div className="panel__header">
+        <h2>Agent Roster & Macro Builder</h2>
+        <p>Mix personas, queue macros, and keep background tasks visible.</p>
+      </div>
+      <div className="panel__grid">
+        <div className="panel__card">
+          <p className="panel__label">Roster</p>
+          <ul className="panel__list">
+            {agentRoster.map(agent => (
+              <li key={agent.name} className="agent">
+                <div>
+                  <p className="agent__name">{agent.name}</p>
+                  <p className="agent__role">{agent.role} • {agent.focus}</p>
+                </div>
+                <span className={`pill ${agent.status === 'online' ? 'pill--active' : ''}`} aria-label={agent.status}>
+                  {agent.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Macro Presets</p>
+          <div className="macros">
+            {macroPresets.map(macro => (
+              <button
+                key={macro.label}
+                className={`playlist__item ${macro.label === selectedMacro.label ? 'playlist__item--active' : ''}`}
+                onClick={() => setSelectedMacro(macro)}
+                onKeyDown={e => e.key === 'Enter' && setSelectedMacro(macro)}
+                aria-pressed={macro.label === selectedMacro.label}
+              >
+                <div>
+                  <p className="playlist__title">{macro.label}</p>
+                  <p className="playlist__meta">{macro.text}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+          <div className="macro-preview" aria-live="polite">
+            <p className="panel__label">Preview</p>
+            <p className="macro-preview__text">{selectedMacro.text}</p>
+          </div>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Background Queue</p>
+          <ul className="panel__list">
+            <li>Prefetch assets for Repomind ribbons</li>
+            <li>Validate header links to avoid 404s</li>
+            <li>Cache graph presets for offline mode</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+
+  const renderMotionPanel = () => (
+    <section className="control-deck__panel">
+      <div className="panel__header">
+        <h2>UX Motion Lab</h2>
+        <p>Ambient glow systems, ribbon presets, and layout anchors tuned for the Gitfather deck.</p>
+      </div>
+      <div className="panel__grid">
+        <div className="panel__card">
+          <p className="panel__label">Motion Tracks</p>
+          <div className="quickstarts">
+            {motionTracks.map(track => (
+              <div key={track.title} className="quickstart">
+                <p className="quickstart__title">{track.title}</p>
+                <p className="quickstart__meta">{track.detail}</p>
+                <span className="quickstart__cta">{track.density}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Widget Shelf</p>
+          <ul className="panel__list">
+            {widgetShelf.map(widget => (
+              <li key={widget.title} className="agent">
+                <div>
+                  <p className="agent__name">{widget.title}</p>
+                  <p className="agent__role">{widget.detail}</p>
+                </div>
+                <span className={`pill ${widget.status === 'Live' ? 'pill--active' : ''}`}>{widget.status}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Stage Directions</p>
+          <ul className="panel__list">
+            <li>Pin the Motion Lab to keep ribbons visible on scroll.</li>
+            <li>Use command palette to swap themes mid-automation.</li>
+            <li>Toggle low-power mode for meeting demos.</li>
+          </ul>
+          <p className="panel__note">HUD load tones shift between cool, balanced, and warm.</p>
+        </div>
+      </div>
+    </section>
+  )
+
+  const renderDocsPanel = () => (
+    <section className="control-deck__panel">
+      <div className="panel__header">
+        <h2>Guidance Rail</h2>
+        <p>Quick-start cards, shortcuts, and helpful actions for first-time visitors.</p>
+      </div>
+      <div className="panel__grid panel__grid--two">
+        <div className="panel__card">
+          <p className="panel__label">Quick Start</p>
+          <div className="quickstarts">
+            {quickStarts.map(tile => (
+              <div key={tile.title} className="quickstart">
+                <p className="quickstart__title">{tile.title}</p>
+                <p className="quickstart__meta">{tile.detail}</p>
+                <span className="quickstart__cta">{tile.cta}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="panel__card">
+          <p className="panel__label">Actions & Shortcuts</p>
+          <ul className="panel__list">
+            {actions.map(action => (
+              <li key={action} className={action === focusedAction ? 'highlighted' : ''}>
+                <button
+                  className="linkish"
+                  onFocus={() => setFocusedAction(action)}
+                  onMouseEnter={() => setFocusedAction(action)}
+                  onClick={() => setFocusedAction(action)}
+                  onKeyDown={e => e.key === 'Enter' && setFocusedAction(action)}
+                >
+                  {action}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <p className="panel__note">Command palette mirrors these entries.</p>
+        </div>
+      </div>
+    </section>
+  )
+
+  return (
+    <div className={`control-deck theme-${activeTheme}`}>
+      <div className="control-deck__background" aria-hidden>
+        <div className="control-deck__ribbon control-deck__ribbon--a" />
+        <div className="control-deck__ribbon control-deck__ribbon--b" />
+        <div className="control-deck__grid" />
+      </div>
+      {renderHeader()}
+      <div className="control-deck__body">
+        {renderNav()}
+        <main className="control-deck__main" aria-live="polite">
+          {renderHud()}
+          {activePanel === 'graph' && renderGraphPanel()}
+          {activePanel === 'video' && renderVideoPanel()}
+          {activePanel === 'agents' && renderAgentsPanel()}
+          {activePanel === 'motion' && renderMotionPanel()}
+          {activePanel === 'docs' && renderDocsPanel()}
+        </main>
+      </div>
+
+      {commandOpen && (
+        <div className="command" role="dialog" aria-modal="true" aria-label="Command palette" onClick={() => setCommandOpen(false)}>
+          <div className="command__content" onClick={e => e.stopPropagation()}>
+            <div className="command__header">
+              <p>Command Palette</p>
+              <p className="command__hint">⇧⌘P / ⇧Ctrl+P</p>
+            </div>
+            <div className="command__actions">
+              {actions.map(action => (
+                <button
+                  key={action}
+                  className={`command__item ${action === focusedAction ? 'command__item--active' : ''}`}
+                  onMouseEnter={() => setFocusedAction(action)}
+                  onFocus={() => setFocusedAction(action)}
+                  onClick={() => {
+                    setFocusedAction(action)
+                    setCommandOpen(false)
+                  }}
+                >
+                  {action}
+                </button>
+              ))}
+            </div>
+            <p className="panel__note">Palette mirrors dock actions and macros. Esc to close.</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/app/src/pages/NodeGraphEditor.tsx
+++ b/app/src/pages/NodeGraphEditor.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { computeClusterBounds, computeShortestPath, filterNodesByCluster } from '../utils/graph';
 
 // Custom Node Graph implementation (n8n-style interactive workflow)
 // Using SVG-based approach for maximum compatibility
@@ -14,6 +15,7 @@ interface Node {
   connections: string[];
   status?: 'completed' | 'active' | 'pending';
   metadata?: Record<string, string>;
+  cluster?: string;
 }
 
 interface Edge {
@@ -24,41 +26,88 @@ interface Edge {
   animated?: boolean;
 }
 
-// DevTeam6 Workflow Nodes - representing project architecture
-const initialNodes: Node[] = [
-  // Layer 1 - Entry Points
-  { id: 'start', type: 'start', label: 'DevTeam6', description: 'Repository Entry Point', position: { x: 400, y: 50 }, color: '#00f0ff', icon: '🚀', connections: ['readme', 'pages'], status: 'completed' },
-  
-  // Layer 2 - Core Components
-  { id: 'readme', type: 'data', label: 'README.md', description: 'Visibility Layer - Project Dashboard', position: { x: 200, y: 150 }, color: '#ff00ff', icon: '📄', connections: ['resources', 'navigation', 'badges'], status: 'completed' },
-  { id: 'pages', type: 'cloud', label: 'GitHub Pages', description: 'Interaction Layer - Live Applications', position: { x: 600, y: 150 }, color: '#7b2fff', icon: '🌐', connections: ['3d-demo', 'genui', 'dashboard'], status: 'completed' },
-  
-  // Layer 3 - README Components
-  { id: 'resources', type: 'data', label: 'Resources', description: '1000+ Curated Tools & Links', position: { x: 50, y: 280 }, color: '#00ff88', icon: '📚', connections: ['ai-tools', 'dev-tools', 'cloud-tools'], status: 'completed' },
-  { id: 'navigation', type: 'action', label: 'Navigation', description: 'Quick Jump Buttons', position: { x: 200, y: 280 }, color: '#ff6600', icon: '🧭', connections: [], status: 'completed' },
-  { id: 'badges', type: 'action', label: 'Badges & Stats', description: 'Dynamic Status Indicators', position: { x: 350, y: 280 }, color: '#ffcc00', icon: '🏅', connections: [], status: 'active' },
-  
-  // Layer 3 - Pages Components
-  { id: '3d-demo', type: 'ai', label: '3D Demo', description: 'Three.js Interactive Experience', position: { x: 500, y: 280 }, color: '#00f0ff', icon: '🎮', connections: [], status: 'completed' },
-  { id: 'genui', type: 'ai', label: 'GenUI Playground', description: 'AI Component Generator', position: { x: 650, y: 280 }, color: '#ff00ff', icon: '🎨', connections: [], status: 'completed' },
-  { id: 'dashboard', type: 'process', label: 'Dashboard', description: 'Gamification & Stats', position: { x: 800, y: 280 }, color: '#00ff88', icon: '📊', connections: ['leaderboard', 'achievements'], status: 'completed' },
-  
-  // Layer 4 - Resource Categories
-  { id: 'ai-tools', type: 'ai', label: 'AI Tools', description: 'GPT-5.1, Claude Opus 4.5, Gemini 3', position: { x: 50, y: 420 }, color: '#00f0ff', icon: '🤖', connections: [], status: 'completed' },
-  { id: 'dev-tools', type: 'process', label: 'Dev Tools', description: 'IDEs, CLIs, Extensions', position: { x: 150, y: 420 }, color: '#ff00ff', icon: '⚙️', connections: [], status: 'completed' },
-  { id: 'cloud-tools', type: 'cloud', label: 'Cloud', description: 'AWS, GCP, Azure, Vercel', position: { x: 250, y: 420 }, color: '#7b2fff', icon: '☁️', connections: [], status: 'active' },
-  
-  // Layer 4 - Dashboard Components  
-  { id: 'leaderboard', type: 'data', label: 'Leaderboard', description: 'Top Contributors', position: { x: 700, y: 420 }, color: '#ff6600', icon: '🏆', connections: [], status: 'completed' },
-  { id: 'achievements', type: 'action', label: 'Achievements', description: 'Collectible Badges', position: { x: 850, y: 420 }, color: '#ffcc00', icon: '🎖️', connections: [], status: 'active' },
-  
-  // Layer 5 - Automation
-  { id: 'automation', type: 'security', label: 'GitHub Actions', description: 'CI/CD & Sync Pipelines', position: { x: 400, y: 520 }, color: '#aa00ff', icon: '⚡', connections: ['deploy', 'cvs-sync', 'roadmap-sync'], status: 'active' },
-  
-  // Layer 6 - Workflows
-  { id: 'deploy', type: 'cloud', label: 'Deploy', description: 'Pages Deployment', position: { x: 250, y: 620 }, color: '#00ff88', icon: '🚀', connections: [], status: 'completed' },
-  { id: 'cvs-sync', type: 'process', label: 'CVS Sync', description: 'Hourly Metric Updates', position: { x: 400, y: 620 }, color: '#00f0ff', icon: '🔄', connections: [], status: 'active' },
-  { id: 'roadmap-sync', type: 'action', label: 'Roadmap Sync', description: '6-Hour Progress Updates', position: { x: 550, y: 620 }, color: '#ff00ff', icon: '📋', connections: [], status: 'pending' },
+interface Cluster {
+  id: string;
+  label: string;
+  description: string;
+  color: string;
+  accent: string;
+  nodes: string[];
+}
+
+// DevTeam6 Workflow Nodes - mind map and automation presets
+const mindmapNodes: Node[] = [
+  { id: 'start', type: 'start', label: 'DevTeam6', description: 'Repository Entry Point', position: { x: 420, y: 60 }, color: '#00f0ff', icon: '🚀', connections: ['readme', 'pages'], status: 'completed', cluster: 'core' },
+  { id: 'readme', type: 'data', label: 'README.md', description: 'Visibility Layer - Project Dashboard', position: { x: 240, y: 160 }, color: '#ff00ff', icon: '📄', connections: ['resources', 'navigation', 'badges'], status: 'completed', cluster: 'core' },
+  { id: 'pages', type: 'cloud', label: 'GitHub Pages', description: 'Interaction Layer - Live Applications', position: { x: 640, y: 160 }, color: '#7b2fff', icon: '🌐', connections: ['3d-demo', 'genui', 'dashboard'], status: 'completed', cluster: 'core' },
+
+  { id: 'resources', type: 'data', label: 'Resources', description: '1000+ Curated Tools & Links', position: { x: 90, y: 300 }, color: '#00ff88', icon: '📚', connections: ['ai-tools', 'dev-tools', 'cloud-tools'], status: 'completed', cluster: 'knowledge' },
+  { id: 'navigation', type: 'action', label: 'Navigation', description: 'Quick Jump Buttons', position: { x: 240, y: 300 }, color: '#ff6600', icon: '🧭', connections: [], status: 'completed', cluster: 'knowledge' },
+  { id: 'badges', type: 'action', label: 'Badges & Stats', description: 'Dynamic Status Indicators', position: { x: 390, y: 300 }, color: '#ffcc00', icon: '🏅', connections: [], status: 'active', cluster: 'knowledge' },
+
+  { id: '3d-demo', type: 'ai', label: '3D Demo', description: 'Three.js Interactive Experience', position: { x: 540, y: 300 }, color: '#00f0ff', icon: '🎮', connections: [], status: 'completed', cluster: 'experiences' },
+  { id: 'genui', type: 'ai', label: 'GenUI Playground', description: 'AI Component Generator', position: { x: 700, y: 300 }, color: '#ff00ff', icon: '🎨', connections: [], status: 'completed', cluster: 'experiences' },
+  { id: 'dashboard', type: 'process', label: 'Dashboard', description: 'Gamification & Stats', position: { x: 860, y: 300 }, color: '#00ff88', icon: '📊', connections: ['leaderboard', 'achievements'], status: 'completed', cluster: 'experiences' },
+
+  { id: 'ai-tools', type: 'ai', label: 'AI Tools', description: 'GPT-5.1, Claude, Gemini', position: { x: 90, y: 460 }, color: '#00f0ff', icon: '🤖', connections: [], status: 'completed', cluster: 'catalog' },
+  { id: 'dev-tools', type: 'process', label: 'Dev Tools', description: 'IDEs, CLIs, Extensions', position: { x: 200, y: 460 }, color: '#ff00ff', icon: '⚙️', connections: [], status: 'completed', cluster: 'catalog' },
+  { id: 'cloud-tools', type: 'cloud', label: 'Cloud', description: 'AWS, GCP, Azure, Vercel', position: { x: 310, y: 460 }, color: '#7b2fff', icon: '☁️', connections: [], status: 'active', cluster: 'catalog' },
+
+  { id: 'leaderboard', type: 'data', label: 'Leaderboard', description: 'Top Contributors', position: { x: 760, y: 460 }, color: '#ff6600', icon: '🏆', connections: [], status: 'completed', cluster: 'engagement' },
+  { id: 'achievements', type: 'action', label: 'Achievements', description: 'Collectible Badges', position: { x: 900, y: 460 }, color: '#ffcc00', icon: '🎖️', connections: [], status: 'active', cluster: 'engagement' },
+
+  { id: 'automation', type: 'security', label: 'GitHub Actions', description: 'CI/CD & Sync Pipelines', position: { x: 480, y: 560 }, color: '#aa00ff', icon: '⚡', connections: ['deploy', 'cvs-sync', 'roadmap-sync'], status: 'active', cluster: 'automation' },
+  { id: 'deploy', type: 'cloud', label: 'Deploy', description: 'Pages Deployment', position: { x: 320, y: 640 }, color: '#00ff88', icon: '🚀', connections: [], status: 'completed', cluster: 'automation' },
+  { id: 'cvs-sync', type: 'process', label: 'CVS Sync', description: 'Hourly Metric Updates', position: { x: 480, y: 640 }, color: '#00f0ff', icon: '🔄', connections: [], status: 'active', cluster: 'automation' },
+  { id: 'roadmap-sync', type: 'action', label: 'Roadmap Sync', description: '6-Hour Progress Updates', position: { x: 640, y: 640 }, color: '#ff00ff', icon: '📋', connections: [], status: 'pending', cluster: 'automation' },
+];
+
+const automationNodes: Node[] = [
+  { id: 'trigger', type: 'start', label: 'Webhook Trigger', description: 'n8n / MCP style entry', position: { x: 220, y: 120 }, color: '#00f0ff', icon: '🛰️', connections: ['ingest'], status: 'completed', cluster: 'signals' },
+  { id: 'ingest', type: 'process', label: 'Repo Ingest', description: 'Fetch + watch Git events', position: { x: 420, y: 180 }, color: '#00ff88', icon: '📥', connections: ['vectorize', 'classify'], status: 'active', cluster: 'signals' },
+  { id: 'classify', type: 'decision', label: 'Intent Classifier', description: 'Security / DX routing', position: { x: 220, y: 260 }, color: '#ffcc00', icon: '🧠', connections: ['alerts'], status: 'pending', cluster: 'brain' },
+  { id: 'vectorize', type: 'ai', label: 'Vector Cluster', description: 'Embed nodes -> graph', position: { x: 420, y: 280 }, color: '#7b2fff', icon: '🧬', connections: ['planner', 'widgets'], status: 'active', cluster: 'brain' },
+  { id: 'planner', type: 'ai', label: 'Plan & Route', description: 'CrewAI / MCP planner', position: { x: 620, y: 260 }, color: '#ff00ff', icon: '🗺️', connections: ['exec'], status: 'completed', cluster: 'brain' },
+  { id: 'exec', type: 'action', label: 'Action Runner', description: 'Runs pipelines & tests', position: { x: 620, y: 360 }, color: '#00ff88', icon: '⚙️', connections: ['deploy-auto'], status: 'active', cluster: 'delivery' },
+  { id: 'widgets', type: 'data', label: 'UX Widgets', description: 'Dashboard + overlays', position: { x: 420, y: 380 }, color: '#00f0ff', icon: '🧩', connections: ['exec'], status: 'completed', cluster: 'delivery' },
+  { id: 'alerts', type: 'security', label: 'Security Gates', description: 'Guardrails + approvals', position: { x: 220, y: 360 }, color: '#ff6600', icon: '🛡️', connections: ['exec'], status: 'active', cluster: 'delivery' },
+  { id: 'deploy-auto', type: 'cloud', label: 'Deploy + Sync', description: 'Ship to Pages + hub', position: { x: 820, y: 320 }, color: '#00ff88', icon: '☁️', connections: ['observability'], status: 'pending', cluster: 'delivery' },
+  { id: 'observability', type: 'process', label: 'Observability', description: 'Dashboards + reports', position: { x: 820, y: 420 }, color: '#ffcc00', icon: '📊', connections: ['retro'], status: 'completed', cluster: 'delivery' },
+  { id: 'retro', type: 'end', label: 'Retro & Learn', description: 'Feedback into vector mind', position: { x: 620, y: 460 }, color: '#ff00ff', icon: '🔁', connections: ['vectorize'], status: 'active', cluster: 'brain' },
+];
+
+const clustersByPreset: Record<string, Cluster[]> = {
+  mindmap: [
+    { id: 'core', label: 'Core OS', description: 'Entrypoint + GitHub Pages', color: '#00f0ff', accent: 'rgba(0, 240, 255, 0.25)', nodes: ['start', 'readme', 'pages'] },
+    { id: 'knowledge', label: 'Knowledge Hub', description: 'Navigation + badges', color: '#ff6600', accent: 'rgba(255, 102, 0, 0.18)', nodes: ['resources', 'navigation', 'badges'] },
+    { id: 'experiences', label: 'Experiences', description: '3D + GenUI + Dashboard', color: '#ff00ff', accent: 'rgba(255, 0, 255, 0.18)', nodes: ['3d-demo', 'genui', 'dashboard'] },
+    { id: 'catalog', label: 'Tool Catalog', description: 'AI/Dev/Cloud curations', color: '#00ff88', accent: 'rgba(0, 255, 136, 0.18)', nodes: ['ai-tools', 'dev-tools', 'cloud-tools'] },
+    { id: 'engagement', label: 'Engagement', description: 'Leaderboard + achievements', color: '#ffcc00', accent: 'rgba(255, 204, 0, 0.18)', nodes: ['leaderboard', 'achievements'] },
+    { id: 'automation', label: 'Automation', description: 'CI/CD + roadmap sync', color: '#aa00ff', accent: 'rgba(170, 0, 255, 0.18)', nodes: ['automation', 'deploy', 'cvs-sync', 'roadmap-sync'] },
+  ],
+  automation: [
+    { id: 'signals', label: 'Signals', description: 'Triggers + ingest', color: '#00f0ff', accent: 'rgba(0, 240, 255, 0.2)', nodes: ['trigger', 'ingest'] },
+    { id: 'brain', label: 'Vector Brain', description: 'Cluster + plan + retro', color: '#ff00ff', accent: 'rgba(255, 0, 255, 0.16)', nodes: ['classify', 'vectorize', 'planner', 'retro'] },
+    { id: 'delivery', label: 'Delivery', description: 'Alerts, exec, deploy', color: '#00ff88', accent: 'rgba(0, 255, 136, 0.16)', nodes: ['alerts', 'widgets', 'exec', 'deploy-auto', 'observability'] },
+  ],
+};
+
+const presets = [
+  { id: 'mindmap', label: 'Knowledge Mind Map', accent: '#00f0ff', nodes: mindmapNodes },
+  { id: 'automation', label: 'n8n Automation', accent: '#ff00ff', nodes: automationNodes },
+];
+
+const widgetCards = [
+  { title: 'Vector Clusters', value: '12 live', detail: 'Embedding + relationship map', color: '#00f0ff', icon: '🧠' },
+  { title: 'Automation Pipelines', value: '7 active', detail: 'Drive-through MCP lanes', color: '#ff00ff', icon: '🛠️' },
+  { title: 'Security Gates', value: '3 enforced', detail: 'Static analysis + approvals', color: '#ff6600', icon: '🛡️' },
+  { title: 'Telemetry', value: 'Realtime', detail: 'Latency 38ms | Uptime 99.99%', color: '#00ff88', icon: '📡' },
+];
+
+const controlPresets = [
+  { id: 'cinematic', label: 'Cinematic Grid', description: 'Tron lattice with neon flow' },
+  { id: 'nebula', label: 'Nebula Glow', description: 'Gradient bloom + halos' },
+  { id: 'vector', label: 'Vector Fog', description: 'Clusters framed for n8n' },
 ];
 
 // Generate edges from node connections
@@ -79,15 +128,17 @@ const generateEdges = (nodes: Node[]): Edge[] => {
 
 // Node Component
 const NodeComponent = ({ 
-  node, 
-  isSelected, 
+  node,
+  isSelected,
+  isPathFocus,
   onClick,
   onDragStart,
   onDrag,
   onDragEnd
-}: { 
-  node: Node; 
+}: {
+  node: Node;
   isSelected: boolean;
+  isPathFocus: boolean;
   onClick: () => void;
   onDragStart: (e: React.MouseEvent) => void;
   onDrag: (e: React.MouseEvent) => void;
@@ -100,7 +151,7 @@ const NodeComponent = ({
   };
 
   return (
-    <g 
+    <g
       transform={`translate(${node.position.x}, ${node.position.y})`}
       onClick={onClick}
       onMouseDown={onDragStart}
@@ -120,7 +171,7 @@ const NodeComponent = ({
           <stop offset="100%" stopColor="#0a0a1a" stopOpacity="0.9"/>
         </linearGradient>
       </defs>
-      
+
       {/* Selection ring */}
       {isSelected && (
         <rect
@@ -138,7 +189,22 @@ const NodeComponent = ({
           <animate attributeName="stroke-dashoffset" from="0" to="20" dur="1s" repeatCount="indefinite"/>
         </rect>
       )}
-      
+
+      {!isSelected && isPathFocus && (
+        <rect
+          x="-70"
+          y="-32"
+          width="140"
+          height="64"
+          rx="10"
+          fill="none"
+          stroke={node.color}
+          strokeWidth="2"
+          opacity="0.6"
+          strokeDasharray="3,6"
+        />
+      )}
+
       {/* Node background */}
       <rect
         x="-65"
@@ -148,7 +214,7 @@ const NodeComponent = ({
         rx="8"
         fill={`url(#grad-${node.id})`}
         stroke={node.color}
-        strokeWidth={isSelected ? 2 : 1.5}
+        strokeWidth={isSelected || isPathFocus ? 2 : 1.5}
         filter={isSelected ? `url(#glow-${node.id})` : undefined}
       />
       
@@ -172,15 +238,19 @@ const NodeComponent = ({
       
       {/* Type badge */}
       <text x="5" y="12" fontSize="8" fill={node.color} textAnchor="middle" opacity="0.8">{node.type.toUpperCase()}</text>
+
+      {isPathFocus && (
+        <text x="55" y="18" fontSize="8" fill="#00ff88" textAnchor="end" opacity="0.85">PATH</text>
+      )}
     </g>
   );
 };
 
 // Edge Component with animated flow
-const EdgeComponent = ({ edge, nodes }: { edge: Edge; nodes: Node[] }) => {
+const EdgeComponent = ({ edge, nodes, isHighlighted }: { edge: Edge; nodes: Node[]; isHighlighted: boolean }) => {
   const fromNode = nodes.find(n => n.id === edge.from);
   const toNode = nodes.find(n => n.id === edge.to);
-  
+
   if (!fromNode || !toNode) return null;
   
   // Calculate path
@@ -200,8 +270,8 @@ const EdgeComponent = ({ edge, nodes }: { edge: Edge; nodes: Node[] }) => {
         d={path}
         fill="none"
         stroke={fromNode.color}
-        strokeWidth="2"
-        opacity="0.6"
+        strokeWidth={isHighlighted ? 3 : 2}
+        opacity={isHighlighted ? 0.9 : 0.6}
         markerEnd="url(#arrowhead)"
       />
       
@@ -217,24 +287,84 @@ const EdgeComponent = ({ edge, nodes }: { edge: Edge; nodes: Node[] }) => {
 
 // Main Component
 export default function NodeGraphEditor() {
-  const [nodes, setNodes] = useState<Node[]>(initialNodes);
+  const [nodes, setNodes] = useState<Node[]>(() => mindmapNodes.map(node => ({ ...node })));
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [viewMode, setViewMode] = useState<'graph' | 'list'>('graph');
+  const [activePresetId, setActivePresetId] = useState<'mindmap' | 'automation'>('mindmap');
+  const [activeCluster, setActiveCluster] = useState<string>('all');
+  const [backgroundStyle, setBackgroundStyle] = useState<'cinematic' | 'nebula' | 'vector'>('cinematic');
   const [isDragging, setIsDragging] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
-  
-  const edges = useMemo(() => generateEdges(nodes), [nodes]);
-  
+  const [pathStart, setPathStart] = useState<string>(mindmapNodes[0]?.id ?? '');
+  const [pathTarget, setPathTarget] = useState<string>(mindmapNodes[1]?.id ?? '');
+
+  const activePreset = presets.find(preset => preset.id === activePresetId) || presets[0];
+  const clusters = clustersByPreset[activePresetId];
+  const displayNodes = useMemo(() => filterNodesByCluster(nodes, activeCluster), [nodes, activeCluster]);
+  const edges = useMemo(() => generateEdges(displayNodes), [displayNodes]);
+  const visibleNodeIds = useMemo(() => new Set(displayNodes.map(node => node.id)), [displayNodes]);
+  const pathEdges = useMemo(() => displayNodes.flatMap(node =>
+    node.connections
+      .filter(targetId => visibleNodeIds.has(targetId))
+      .map(targetId => ({ from: node.id, to: targetId }))
+  ), [displayNodes, visibleNodeIds]);
+  const pathSequence = useMemo(
+    () => computeShortestPath(pathEdges, pathStart, pathTarget),
+    [pathEdges, pathStart, pathTarget]
+  );
+  const pathNodeIds = useMemo(() => new Set(pathSequence), [pathSequence]);
+  const pathEdgeIds = useMemo(() => new Set(pathSequence
+    .map((nodeId, index) => pathSequence[index + 1] ? `${nodeId}-${pathSequence[index + 1]}` : null)
+    .filter(Boolean) as string[]
+  ), [pathSequence]);
+
   // Statistics
   const stats = useMemo(() => ({
     total: nodes.length,
     completed: nodes.filter(n => n.status === 'completed').length,
     active: nodes.filter(n => n.status === 'active').length,
     pending: nodes.filter(n => n.status === 'pending').length,
-  }), [nodes]);
-  
+    visible: displayNodes.length,
+  }), [nodes, displayNodes]);
+
+  const backgroundGradient = useMemo(() => {
+    if (backgroundStyle === 'nebula') {
+      return 'radial-gradient(circle at 20% 20%, rgba(0, 240, 255, 0.18), transparent 32%), radial-gradient(circle at 80% 30%, rgba(255, 0, 255, 0.16), transparent 34%), radial-gradient(circle at 50% 70%, rgba(0, 255, 136, 0.12), transparent 28%), #0a0a1a'
+    }
+    if (backgroundStyle === 'vector') {
+      return 'linear-gradient(135deg, #050710 0%, #0c1124 50%, #050710 100%)'
+    }
+    return 'linear-gradient(135deg, #0a0a1a 0%, #1a0a2e 50%, #0a0a1a 100%)'
+  }, [backgroundStyle]);
+
+  useEffect(() => {
+    if (displayNodes.length === 0) return;
+    if (!displayNodes.some(node => node.id === pathStart)) {
+      setPathStart(displayNodes[0].id);
+    }
+    if (!displayNodes.some(node => node.id === pathTarget)) {
+      const fallbackTarget = displayNodes[1]?.id ?? displayNodes[0].id;
+      setPathTarget(fallbackTarget);
+    }
+  }, [displayNodes, pathStart, pathTarget]);
+
+  const clusterBounds = useMemo(() => clusters
+    .map(cluster => ({ cluster, bounds: computeClusterBounds(nodes, cluster.id, backgroundStyle === 'vector' ? 64 : 48) }))
+    .filter(item => Boolean(item.bounds)), [clusters, nodes, backgroundStyle]);
+
+  const handlePresetChange = useCallback((presetId: 'mindmap' | 'automation') => {
+    const preset = presets.find(item => item.id === presetId);
+    if (!preset) return;
+    setNodes(preset.nodes.map(node => ({ ...node })));
+    setActivePresetId(presetId);
+    setSelectedNode(null);
+    setActiveCluster('all');
+    setPathStart(preset.nodes[0]?.id ?? '');
+    setPathTarget(preset.nodes[1]?.id ?? preset.nodes[0]?.id ?? '');
+  }, []);
+
   const handleNodeClick = useCallback((node: Node) => {
     setSelectedNode(selectedNode?.id === node.id ? null : node);
   }, [selectedNode]);
@@ -276,65 +406,118 @@ export default function NodeGraphEditor() {
   return (
     <div style={{
       minHeight: '100vh',
-      background: 'linear-gradient(135deg, #0a0a1a 0%, #1a0a2e 50%, #0a0a1a 100%)',
+      background: backgroundGradient,
       color: '#ffffff',
       fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
     }}>
       {/* Header */}
       <header style={{
-        padding: '20px 40px',
+        padding: '20px 32px',
         borderBottom: '1px solid rgba(0, 240, 255, 0.3)',
         display: 'flex',
         justifyContent: 'space-between',
+        gap: '20px',
         alignItems: 'center',
         background: 'rgba(10, 10, 26, 0.9)',
         backdropFilter: 'blur(10px)',
       }}>
-        <div>
-          <h1 style={{
-            margin: 0,
-            fontSize: '28px',
-            background: 'linear-gradient(90deg, #00f0ff, #ff00ff, #00ff88)',
-            WebkitBackgroundClip: 'text',
-            WebkitTextFillColor: 'transparent',
-          }}>
-            ⚡ Node Graph Editor
-          </h1>
-          <p style={{ margin: '5px 0 0', opacity: 0.7, fontSize: '14px' }}>
-            Interactive n8n-style workflow visualization
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <h1 style={{
+              margin: 0,
+              fontSize: '28px',
+              background: 'linear-gradient(90deg, #00f0ff, #ff00ff, #00ff88)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+            }}>
+              ⚡ The Gitfather Flow Grid
+            </h1>
+            <span style={{
+              padding: '6px 10px',
+              border: '1px solid rgba(255,255,255,0.15)',
+              borderRadius: '999px',
+              fontSize: '12px',
+              color: '#9ae6ff',
+              background: 'rgba(0, 240, 255, 0.08)'
+            }}>
+              {activePreset.label} · {clusters.length} clusters
+            </span>
+          </div>
+          <p style={{ margin: 0, opacity: 0.78, fontSize: '14px' }}>
+            n8n-inspired automation canvas with vector cluster halos, Tron gradients, and MCP drive-through prompts.
           </p>
+          <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+            {controlPresets.map(control => (
+              <button
+                key={control.id}
+                onClick={() => setBackgroundStyle(control.id as typeof backgroundStyle)}
+                style={{
+                  padding: '8px 12px',
+                  borderRadius: '999px',
+                  border: backgroundStyle === control.id ? '1px solid #ff00ff' : '1px solid rgba(255,255,255,0.15)',
+                  background: backgroundStyle === control.id ? 'rgba(255,0,255,0.18)' : 'rgba(255,255,255,0.05)',
+                  color: '#ffffff',
+                  cursor: 'pointer',
+                  fontSize: '12px',
+                }}
+              >
+                {control.label}
+              </button>
+            ))}
+          </div>
         </div>
-        
-        <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
-          <a 
-            href="/DevTeam6/" 
-            style={{
-              padding: '10px 20px',
-              background: 'rgba(0, 240, 255, 0.2)',
-              border: '1px solid #00f0ff',
-              borderRadius: '8px',
-              color: '#00f0ff',
-              textDecoration: 'none',
-              fontSize: '14px',
-            }}
-          >
-            🏠 Home
-          </a>
-          
-          <button
-            onClick={() => setViewMode(viewMode === 'graph' ? 'list' : 'graph')}
-            style={{
-              padding: '10px 20px',
-              background: viewMode === 'graph' ? 'rgba(255, 0, 255, 0.2)' : 'rgba(0, 255, 136, 0.2)',
-              border: `1px solid ${viewMode === 'graph' ? '#ff00ff' : '#00ff88'}`,
-              borderRadius: '8px',
-              color: viewMode === 'graph' ? '#ff00ff' : '#00ff88',
-              cursor: 'pointer',
-              fontSize: '14px',
-            }}
-          >
-            {viewMode === 'graph' ? '📋 List View' : '🔀 Graph View'}
-          </button>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', alignItems: 'flex-end' }}>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+            {presets.map(preset => (
+              <button
+                key={preset.id}
+                onClick={() => handlePresetChange(preset.id as 'mindmap' | 'automation')}
+                style={{
+                  padding: '10px 14px',
+                  background: activePresetId === preset.id ? 'rgba(0, 240, 255, 0.15)' : 'rgba(255, 255, 255, 0.04)',
+                  border: `1px solid ${activePresetId === preset.id ? preset.accent : 'rgba(255,255,255,0.15)'}`,
+                  borderRadius: '10px',
+                  color: '#ffffff',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+              >
+                {preset.id === 'automation' ? '🤖 Automation' : '🧭 Mind Map'}
+              </button>
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+            <a
+              href="/DevTeam6/"
+              style={{
+                padding: '10px 20px',
+                background: 'rgba(0, 240, 255, 0.2)',
+                border: '1px solid #00f0ff',
+                borderRadius: '8px',
+                color: '#00f0ff',
+                textDecoration: 'none',
+                fontSize: '14px',
+              }}
+            >
+              🏠 Home
+            </a>
+
+            <button
+              onClick={() => setViewMode(viewMode === 'graph' ? 'list' : 'graph')}
+              style={{
+                padding: '10px 20px',
+                background: viewMode === 'graph' ? 'rgba(255, 0, 255, 0.2)' : 'rgba(0, 255, 136, 0.2)',
+                border: `1px solid ${viewMode === 'graph' ? '#ff00ff' : '#00ff88'}`,
+                borderRadius: '8px',
+                color: viewMode === 'graph' ? '#ff00ff' : '#00ff88',
+                cursor: 'pointer',
+                fontSize: '14px',
+              }}
+            >
+              {viewMode === 'graph' ? '📋 List View' : '🔀 Graph View'}
+            </button>
+          </div>
         </div>
       </header>
       
@@ -343,8 +526,8 @@ export default function NodeGraphEditor() {
         display: 'flex',
         justifyContent: 'center',
         gap: '30px',
-        padding: '15px',
-        background: 'rgba(0, 240, 255, 0.05)',
+        padding: '16px 20px',
+        background: 'linear-gradient(90deg, rgba(0,240,255,0.08), rgba(255,0,255,0.05))',
         borderBottom: '1px solid rgba(0, 240, 255, 0.2)',
       }}>
         <div style={{ textAlign: 'center' }}>
@@ -363,6 +546,10 @@ export default function NodeGraphEditor() {
           <div style={{ fontSize: '24px', fontWeight: 'bold', color: '#ff6600' }}>{stats.pending}</div>
           <div style={{ fontSize: '12px', opacity: 0.7 }}>Pending</div>
         </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: '24px', fontWeight: 'bold', color: '#7b2fff' }}>{stats.visible}</div>
+          <div style={{ fontSize: '12px', opacity: 0.7 }}>Visible in View</div>
+        </div>
       </div>
       
       <div style={{ display: 'flex', height: 'calc(100vh - 150px)' }}>
@@ -370,6 +557,49 @@ export default function NodeGraphEditor() {
         <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
           {viewMode === 'graph' ? (
             <>
+              {/* Cluster Filters */}
+              <div style={{
+                position: 'absolute',
+                top: '20px',
+                left: '20px',
+                display: 'flex',
+                gap: '8px',
+                flexWrap: 'wrap',
+                zIndex: 10,
+              }}>
+                <button
+                  onClick={() => setActiveCluster('all')}
+                  style={{
+                    padding: '8px 12px',
+                    borderRadius: '10px',
+                    border: activeCluster === 'all' ? '1px solid #00f0ff' : '1px solid rgba(255,255,255,0.2)',
+                    background: activeCluster === 'all' ? 'rgba(0, 240, 255, 0.2)' : 'rgba(255,255,255,0.05)',
+                    color: '#ffffff',
+                    cursor: 'pointer',
+                    fontSize: '12px',
+                  }}
+                >
+                  🌐 All clusters
+                </button>
+                {clusters.map(cluster => (
+                  <button
+                    key={cluster.id}
+                    onClick={() => setActiveCluster(cluster.id === activeCluster ? 'all' : cluster.id)}
+                    style={{
+                      padding: '8px 12px',
+                      borderRadius: '10px',
+                      border: `1px solid ${cluster.color}`,
+                      background: activeCluster === cluster.id ? `${cluster.accent}` : 'rgba(255,255,255,0.05)',
+                      color: '#ffffff',
+                      cursor: 'pointer',
+                      fontSize: '12px',
+                    }}
+                  >
+                    {cluster.label}
+                  </button>
+                ))}
+              </div>
+
               {/* Zoom Controls */}
               <div style={{
                 position: 'absolute',
@@ -433,7 +663,7 @@ export default function NodeGraphEditor() {
                 width="100%"
                 height="100%"
                 style={{
-                  background: 'radial-gradient(circle at center, rgba(0, 240, 255, 0.05) 0%, transparent 70%)',
+                  background: 'radial-gradient(circle at center, rgba(0, 240, 255, 0.08) 0%, transparent 70%)',
                 }}
                 onMouseMove={handleDrag}
                 onMouseUp={handleDragEnd}
@@ -442,7 +672,7 @@ export default function NodeGraphEditor() {
                 {/* Grid pattern */}
                 <defs>
                   <pattern id="grid" width="50" height="50" patternUnits="userSpaceOnUse">
-                    <path d="M 50 0 L 0 0 0 50" fill="none" stroke="rgba(0, 240, 255, 0.1)" strokeWidth="0.5"/>
+                    <path d="M 50 0 L 0 0 0 50" fill="none" stroke={backgroundStyle === 'cinematic' ? 'rgba(0, 240, 255, 0.12)' : 'rgba(255, 0, 255, 0.08)'} strokeWidth="0.6"/>
                   </pattern>
                   <marker
                     id="arrowhead"
@@ -456,19 +686,52 @@ export default function NodeGraphEditor() {
                   </marker>
                 </defs>
                 <rect width="100%" height="100%" fill="url(#grid)"/>
-                
+
                 <g transform={`translate(${pan.x}, ${pan.y}) scale(${zoom})`}>
+                  {/* Cluster halos */}
+                  {clusterBounds.map(item => item.bounds && (
+                    <g key={item.cluster.id}>
+                      <rect
+                        x={item.bounds.minX}
+                        y={item.bounds.minY}
+                        width={item.bounds.width}
+                        height={item.bounds.height}
+                        rx="18"
+                        fill={item.cluster.accent}
+                        stroke={activeCluster === item.cluster.id ? '#ffffff' : item.cluster.color}
+                        strokeWidth={activeCluster === item.cluster.id ? 2.4 : 1.5}
+                        opacity={activeCluster === 'all' || activeCluster === item.cluster.id ? 0.8 : 0.35}
+                      />
+                      <text
+                        x={item.bounds.centerX}
+                        y={item.bounds.minY + 18}
+                        fontSize="12"
+                        textAnchor="middle"
+                        fill="#ffffff"
+                        opacity="0.9"
+                      >
+                        {item.cluster.label}
+                      </text>
+                    </g>
+                  ))}
+
                   {/* Edges */}
                   {edges.map(edge => (
-                    <EdgeComponent key={edge.id} edge={edge} nodes={nodes}/>
+                    <EdgeComponent
+                      key={edge.id}
+                      edge={edge}
+                      nodes={displayNodes}
+                      isHighlighted={pathEdgeIds.has(edge.id)}
+                    />
                   ))}
-                  
+
                   {/* Nodes */}
-                  {nodes.map(node => (
+                  {displayNodes.map(node => (
                     <NodeComponent
                       key={node.id}
                       node={node}
                       isSelected={selectedNode?.id === node.id}
+                      isPathFocus={pathNodeIds.has(node.id)}
                       onClick={() => handleNodeClick(node)}
                       onDragStart={(e) => handleDragStart(node, e)}
                       onDrag={handleDrag}
@@ -487,16 +750,17 @@ export default function NodeGraphEditor() {
                     <th style={{ padding: '10px', textAlign: 'left', color: '#00f0ff' }}>Node</th>
                     <th style={{ padding: '10px', textAlign: 'left', color: '#ff00ff' }}>Type</th>
                     <th style={{ padding: '10px', textAlign: 'left', color: '#00ff88' }}>Description</th>
+                    <th style={{ padding: '10px', textAlign: 'left', color: '#7b2fff' }}>Cluster</th>
                     <th style={{ padding: '10px', textAlign: 'center', color: '#ffcc00' }}>Status</th>
                     <th style={{ padding: '10px', textAlign: 'center', color: '#ff6600' }}>Connections</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {nodes.map(node => (
-                    <tr 
+                  {displayNodes.map(node => (
+                    <tr
                       key={node.id}
                       onClick={() => handleNodeClick(node)}
-                      style={{ 
+                      style={{
                         borderBottom: '1px solid rgba(255,255,255,0.1)',
                         cursor: 'pointer',
                         background: selectedNode?.id === node.id ? 'rgba(0, 240, 255, 0.1)' : 'transparent',
@@ -508,6 +772,7 @@ export default function NodeGraphEditor() {
                       </td>
                       <td style={{ padding: '12px', opacity: 0.7 }}>{node.type}</td>
                       <td style={{ padding: '12px', opacity: 0.7, fontSize: '13px' }}>{node.description}</td>
+                      <td style={{ padding: '12px', color: '#9ae6ff', fontSize: '12px' }}>{node.cluster || '—'}</td>
                       <td style={{ padding: '12px', textAlign: 'center' }}>
                         <select
                           value={node.status}
@@ -547,162 +812,304 @@ export default function NodeGraphEditor() {
           )}
         </div>
         
-        {/* Side Panel - Node Details */}
-        {selectedNode && (
+        {/* Side Panel - Node Details + Widgets */}
+        <div style={{
+          width: '380px',
+          background: 'rgba(10, 10, 26, 0.95)',
+          borderLeft: '1px solid rgba(0, 240, 255, 0.25)',
+          padding: '20px',
+          overflow: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+        }}>
           <div style={{
-            width: '350px',
-            background: 'rgba(10, 10, 26, 0.95)',
-            borderLeft: `2px solid ${selectedNode.color}`,
-            padding: '20px',
-            overflow: 'auto',
+            border: '1px solid rgba(0, 240, 255, 0.35)',
+            background: 'linear-gradient(135deg, rgba(0,240,255,0.08), rgba(255,0,255,0.06))',
+            borderRadius: '12px',
+            padding: '12px',
           }}>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: '20px',
-            }}>
-              <h2 style={{ 
-                margin: 0, 
-                color: selectedNode.color,
-                display: 'flex',
-                alignItems: 'center',
-                gap: '10px',
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+              <div>
+                <div style={{ fontSize: '12px', letterSpacing: '0.08em', color: '#9ae6ff' }}>PATH PLAYBOOK</div>
+                <div style={{ fontSize: '14px', fontWeight: 'bold', color: '#ffffff' }}>Shortest Tron route between visible nodes</div>
+              </div>
+              <div style={{
+                padding: '6px 10px',
+                borderRadius: '10px',
+                background: pathSequence.length > 0 ? 'rgba(0,255,136,0.18)' : 'rgba(255,102,0,0.18)',
+                color: pathSequence.length > 0 ? '#00ff88' : '#ff9966',
+                fontSize: '12px',
+                border: '1px solid rgba(255,255,255,0.12)'
               }}>
-                <span style={{ fontSize: '30px' }}>{selectedNode.icon}</span>
-                {selectedNode.label}
-              </h2>
-              <button
-                onClick={() => setSelectedNode(null)}
+                {pathSequence.length > 0 ? `${pathSequence.length - 1} hops` : 'No route'}
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr auto', gap: '8px', alignItems: 'center' }}>
+              <select
+                aria-label="Path start node"
+                value={pathStart}
+                onChange={(e) => setPathStart(e.target.value)}
                 style={{
-                  background: 'transparent',
-                  border: 'none',
-                  color: '#ffffff',
-                  fontSize: '24px',
-                  cursor: 'pointer',
-                  opacity: 0.7,
+                  background: 'rgba(0,0,0,0.35)',
+                  border: '1px solid rgba(0,255,255,0.4)',
+                  color: '#e8f9ff',
+                  borderRadius: '8px',
+                  padding: '8px',
+                  fontSize: '12px',
                 }}
-              >×</button>
-            </div>
-            
-            <div style={{
-              background: `linear-gradient(135deg, ${selectedNode.color}20, transparent)`,
-              padding: '15px',
-              borderRadius: '8px',
-              marginBottom: '15px',
-            }}>
-              <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '5px' }}>DESCRIPTION</div>
-              <div style={{ fontSize: '14px' }}>{selectedNode.description}</div>
-            </div>
-            
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px', marginBottom: '15px' }}>
-              <div style={{
-                background: 'rgba(0, 240, 255, 0.1)',
-                padding: '12px',
-                borderRadius: '8px',
-                textAlign: 'center',
-              }}>
-                <div style={{ fontSize: '12px', opacity: 0.7 }}>TYPE</div>
-                <div style={{ fontSize: '14px', fontWeight: 'bold', color: selectedNode.color }}>
-                  {selectedNode.type.toUpperCase()}
-                </div>
-              </div>
-              <div style={{
-                background: 'rgba(255, 0, 255, 0.1)',
-                padding: '12px',
-                borderRadius: '8px',
-                textAlign: 'center',
-              }}>
-                <div style={{ fontSize: '12px', opacity: 0.7 }}>STATUS</div>
-                <div style={{ 
-                  fontSize: '14px', 
-                  fontWeight: 'bold',
-                  color: selectedNode.status === 'completed' ? '#00ff88' : selectedNode.status === 'active' ? '#ffcc00' : '#ff6600',
-                }}>
-                  {selectedNode.status?.toUpperCase()}
-                </div>
-              </div>
-            </div>
-            
-            <div style={{
-              background: 'rgba(0, 255, 136, 0.1)',
-              padding: '12px',
-              borderRadius: '8px',
-              marginBottom: '15px',
-            }}>
-              <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '8px' }}>POSITION</div>
-              <div style={{ display: 'flex', gap: '15px' }}>
-                <div>
-                  <span style={{ opacity: 0.7 }}>X:</span> 
-                  <span style={{ color: '#00f0ff', marginLeft: '5px' }}>{Math.round(selectedNode.position.x)}</span>
-                </div>
-                <div>
-                  <span style={{ opacity: 0.7 }}>Y:</span> 
-                  <span style={{ color: '#ff00ff', marginLeft: '5px' }}>{Math.round(selectedNode.position.y)}</span>
-                </div>
-              </div>
-            </div>
-            
-            {selectedNode.connections.length > 0 && (
-              <div style={{
-                background: 'rgba(255, 102, 0, 0.1)',
-                padding: '12px',
-                borderRadius: '8px',
-              }}>
-                <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '8px' }}>CONNECTIONS ({selectedNode.connections.length})</div>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-                  {selectedNode.connections.map(connId => {
-                    const connNode = nodes.find(n => n.id === connId);
-                    return connNode ? (
-                      <button
-                        key={connId}
-                        onClick={() => setSelectedNode(connNode)}
-                        style={{
-                          background: `${connNode.color}30`,
-                          border: `1px solid ${connNode.color}`,
-                          borderRadius: '15px',
-                          padding: '5px 12px',
-                          color: connNode.color,
-                          cursor: 'pointer',
-                          fontSize: '12px',
-                        }}
-                      >
-                        {connNode.icon} {connNode.label}
-                      </button>
-                    ) : null;
-                  })}
-                </div>
-              </div>
-            )}
-            
-            <div style={{ marginTop: '20px', padding: '15px', background: 'rgba(123, 47, 255, 0.1)', borderRadius: '8px' }}>
-              <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '10px' }}>CHANGE STATUS</div>
-              <div style={{ display: 'flex', gap: '8px' }}>
-                {(['completed', 'active', 'pending'] as const).map(status => (
-                  <button
-                    key={status}
-                    onClick={() => handleStatusChange(selectedNode.id, status)}
-                    style={{
-                      flex: 1,
-                      padding: '8px',
-                      background: selectedNode.status === status 
-                        ? (status === 'completed' ? '#00ff88' : status === 'active' ? '#ffcc00' : '#ff6600')
-                        : 'transparent',
-                      border: `1px solid ${status === 'completed' ? '#00ff88' : status === 'active' ? '#ffcc00' : '#ff6600'}`,
-                      borderRadius: '6px',
-                      color: selectedNode.status === status ? '#0a0a1a' : (status === 'completed' ? '#00ff88' : status === 'active' ? '#ffcc00' : '#ff6600'),
-                      cursor: 'pointer',
-                      fontSize: '11px',
-                      fontWeight: 'bold',
-                    }}
-                  >
-                    {status === 'completed' ? '✓' : status === 'active' ? '●' : '○'} {status.charAt(0).toUpperCase() + status.slice(1)}
-                  </button>
+              >
+                {displayNodes.length === 0 ? <option value="">No nodes</option> : displayNodes.map(node => (
+                  <option key={node.id} value={node.id}>{node.icon} {node.label}</option>
                 ))}
-              </div>
+              </select>
+
+              <select
+                aria-label="Path target node"
+                value={pathTarget}
+                onChange={(e) => setPathTarget(e.target.value)}
+                style={{
+                  background: 'rgba(0,0,0,0.35)',
+                  border: '1px solid rgba(255,0,255,0.4)',
+                  color: '#e8f9ff',
+                  borderRadius: '8px',
+                  padding: '8px',
+                  fontSize: '12px',
+                }}
+              >
+                {displayNodes.length === 0 ? <option value="">No nodes</option> : displayNodes.map(node => (
+                  <option key={node.id} value={node.id}>{node.icon} {node.label}</option>
+                ))}
+              </select>
+
+              <button
+                aria-label="Swap path start and target"
+                onClick={() => { setPathStart(pathTarget); setPathTarget(pathStart); }}
+                style={{
+                  padding: '8px 10px',
+                  background: 'rgba(0, 240, 255, 0.15)',
+                  border: '1px solid rgba(0, 240, 255, 0.5)',
+                  color: '#00f0ff',
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontSize: '12px',
+                  fontWeight: 'bold',
+                }}
+              >⇄</button>
+            </div>
+
+            <div style={{ marginTop: '10px', display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              {pathSequence.length > 0 ? (
+                pathSequence.map((nodeId, idx) => {
+                  const node = displayNodes.find(item => item.id === nodeId);
+                  return node ? (
+                    <div key={nodeId} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      <span style={{
+                        padding: '6px 10px',
+                        borderRadius: '10px',
+                        background: `${node.color}22`,
+                        border: `1px solid ${node.color}77`,
+                        color: node.color,
+                        fontSize: '12px',
+                      }}>
+                        {node.icon} {node.label}
+                      </span>
+                      {idx < pathSequence.length - 1 && <span style={{ color: '#9ae6ff' }}>→</span>}
+                    </div>
+                  ) : null;
+                })
+              ) : (
+                <div style={{ color: '#ffae7a', fontSize: '12px' }}>
+                  Pick two visible nodes to trace a neon-fast route.
+                </div>
+              )}
             </div>
           </div>
-        )}
+
+          <div>
+            <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '8px' }}>MCP WIDGETS</div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '10px' }}>
+              {widgetCards.map(card => (
+                <div
+                  key={card.title}
+                  style={{
+                    border: `1px solid ${card.color}55`,
+                    background: `${card.color}10`,
+                    borderRadius: '10px',
+                    padding: '10px',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
+                    <span>{card.icon}</span>
+                    <span style={{ fontWeight: 'bold' }}>{card.title}</span>
+                  </div>
+                  <div style={{ color: card.color, fontSize: '14px', fontWeight: 'bold' }}>{card.value}</div>
+                  <div style={{ fontSize: '12px', opacity: 0.8 }}>{card.detail}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {selectedNode ? (
+            <>
+              <div style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}>
+                <h2 style={{
+                  margin: 0,
+                  color: selectedNode.color,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '10px',
+                }}>
+                  <span style={{ fontSize: '30px' }}>{selectedNode.icon}</span>
+                  {selectedNode.label}
+                </h2>
+                <button
+                  onClick={() => setSelectedNode(null)}
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    color: '#ffffff',
+                    fontSize: '24px',
+                    cursor: 'pointer',
+                    opacity: 0.7,
+                  }}
+                >×</button>
+              </div>
+
+              <div style={{
+                background: `linear-gradient(135deg, ${selectedNode.color}20, transparent)`,
+                padding: '15px',
+                borderRadius: '8px',
+              }}>
+                <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '5px' }}>DESCRIPTION</div>
+                <div style={{ fontSize: '14px' }}>{selectedNode.description}</div>
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' }}>
+                <div style={{
+                  background: 'rgba(0, 240, 255, 0.1)',
+                  padding: '12px',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                }}>
+                  <div style={{ fontSize: '12px', opacity: 0.7 }}>TYPE</div>
+                  <div style={{ fontSize: '14px', fontWeight: 'bold', color: selectedNode.color }}>
+                    {selectedNode.type.toUpperCase()}
+                  </div>
+                </div>
+                <div style={{
+                  background: 'rgba(255, 0, 255, 0.1)',
+                  padding: '12px',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                }}>
+                  <div style={{ fontSize: '12px', opacity: 0.7 }}>STATUS</div>
+                  <div style={{
+                    fontSize: '14px',
+                    fontWeight: 'bold',
+                    color: selectedNode.status === 'completed' ? '#00ff88' : selectedNode.status === 'active' ? '#ffcc00' : '#ff6600',
+                  }}>
+                    {selectedNode.status?.toUpperCase()}
+                  </div>
+                </div>
+              </div>
+
+              <div style={{
+                background: 'rgba(0, 255, 136, 0.1)',
+                padding: '12px',
+                borderRadius: '8px',
+              }}>
+                <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '8px' }}>POSITION</div>
+                <div style={{ display: 'flex', gap: '15px' }}>
+                  <div>
+                    <span style={{ opacity: 0.7 }}>X:</span>
+                    <span style={{ color: '#00f0ff', marginLeft: '5px' }}>{Math.round(selectedNode.position.x)}</span>
+                  </div>
+                  <div>
+                    <span style={{ opacity: 0.7 }}>Y:</span>
+                    <span style={{ color: '#ff00ff', marginLeft: '5px' }}>{Math.round(selectedNode.position.y)}</span>
+                  </div>
+                </div>
+              </div>
+
+              {selectedNode.connections.length > 0 && (
+                <div style={{
+                  background: 'rgba(255, 102, 0, 0.1)',
+                  padding: '12px',
+                  borderRadius: '8px',
+                }}>
+                  <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '8px' }}>CONNECTIONS ({selectedNode.connections.length})</div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                    {selectedNode.connections.map(connId => {
+                      const connNode = nodes.find(n => n.id === connId);
+                      return connNode ? (
+                        <button
+                          key={connId}
+                          onClick={() => setSelectedNode(connNode)}
+                          style={{
+                            background: `${connNode.color}30`,
+                            border: `1px solid ${connNode.color}`,
+                            borderRadius: '15px',
+                            padding: '5px 12px',
+                            color: connNode.color,
+                            cursor: 'pointer',
+                            fontSize: '12px',
+                          }}
+                        >
+                          {connNode.icon} {connNode.label}
+                        </button>
+                      ) : null;
+                    })}
+                  </div>
+                </div>
+              )}
+
+              <div style={{ marginTop: '10px', padding: '15px', background: 'rgba(123, 47, 255, 0.12)', borderRadius: '8px' }}>
+                <div style={{ fontSize: '12px', opacity: 0.7, marginBottom: '10px' }}>CHANGE STATUS</div>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                  {(['completed', 'active', 'pending'] as const).map(status => (
+                    <button
+                      key={status}
+                      onClick={() => handleStatusChange(selectedNode.id, status)}
+                      style={{
+                        flex: 1,
+                        padding: '8px',
+                        background: selectedNode.status === status
+                          ? (status === 'completed' ? '#00ff88' : status === 'active' ? '#ffcc00' : '#ff6600')
+                          : 'transparent',
+                        border: `1px solid ${status === 'completed' ? '#00ff88' : status === 'active' ? '#ffcc00' : '#ff6600'}`,
+                        borderRadius: '6px',
+                        color: selectedNode.status === status ? '#0a0a1a' : (status === 'completed' ? '#00ff88' : status === 'active' ? '#ffcc00' : '#ff6600'),
+                        cursor: 'pointer',
+                        fontSize: '11px',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {status === 'completed' ? '✓' : status === 'active' ? '●' : '○'} {status.charAt(0).toUpperCase() + status.slice(1)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </>
+          ) : (
+            <div style={{
+              background: 'rgba(255, 255, 255, 0.04)',
+              border: '1px dashed rgba(255,255,255,0.2)',
+              borderRadius: '10px',
+              padding: '20px',
+              textAlign: 'center',
+              color: '#9ae6ff',
+              fontSize: '13px',
+            }}>
+              Select a node to view its Tron-grade dossier.
+            </div>
+          )}
+        </div>
       </div>
       
       {/* Legend */}

--- a/app/src/pages/Repomind.tsx
+++ b/app/src/pages/Repomind.tsx
@@ -1,0 +1,757 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { composePersonaPrompt, formatStatus } from '../utils/repomind'
+import { extractYouTubeId } from '../utils/youtube'
+import { getPulseTone } from '../utils/visuals'
+
+const defaultVideo = 'https://www.youtube.com/watch?v=VdQkYJ_Rp-k'
+const videoPresets = [
+  { label: 'Omega Trailer', url: 'https://www.youtube.com/watch?v=VdQkYJ_Rp-k' },
+  { label: 'RAG Playbook', url: 'https://www.youtube.com/watch?v=tpe_Y6h6BfM' },
+  { label: 'DX Lightning', url: 'https://www.youtube.com/watch?v=6Dh-RL__uN4' }
+]
+
+interface QuickAction {
+  title: string
+  prompt: string
+  tone: string
+}
+
+interface AgentStatus {
+  name: string
+  role: string
+  mode: string
+  status: 'online' | 'standby'
+}
+
+function YouTubePlayer({ videoUrl, title }: { videoUrl: string; title: string }) {
+  const videoId = useMemo(() => extractYouTubeId(videoUrl), [videoUrl])
+
+  return (
+    <div
+      style={{
+        border: '1px solid rgba(0, 255, 255, 0.2)',
+        borderRadius: '16px',
+        overflow: 'hidden',
+        background: 'rgba(0, 255, 255, 0.05)',
+        boxShadow: '0 20px 60px rgba(0,0,0,0.35)'
+      }}
+    >
+      {videoId ? (
+        <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0 }}>
+          <iframe
+            title={title}
+            src={`https://www.youtube.com/embed/${videoId}?rel=0`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 'none' }}
+          />
+        </div>
+      ) : (
+        <div style={{ padding: '20px', color: '#ff6600', textAlign: 'center', fontWeight: 700 }}>
+          Invalid YouTube link — drop a full URL or 11-character video ID.
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function Repomind() {
+  const [videoInput, setVideoInput] = useState(defaultVideo)
+  const [selectedAction, setSelectedAction] = useState<QuickAction | null>(null)
+  const [selectedPipeline, setSelectedPipeline] = useState('Instant Repo Scan')
+  const [selectedTone, setSelectedTone] = useState('Playful mentor tone with concrete code refs.')
+  const [selectedFocus, setSelectedFocus] = useState('Focus on navigation safety + DX speed.')
+  const [agents, setAgents] = useState<AgentStatus[]>([
+    { name: 'Repomind Prime', role: 'Narrator & Tour Guide', mode: 'Drive-Through', status: 'online' },
+    { name: 'Repomind Jr', role: 'Rapid shortcuts', mode: 'Lite persona', status: 'online' },
+    { name: 'Omega Guardian', role: 'Security + QA', mode: 'Firewall', status: 'standby' },
+    { name: 'MCP Relay', role: 'Multi-agent coordinator', mode: 'Pipelines', status: 'standby' }
+  ])
+
+  const highlightStats = [
+    { label: 'Velocity', value: 92, detail: 'UI flows under 30s build time.', tag: 'Tron lane' },
+    { label: 'Stability', value: 88, detail: '404-immune header routes.', tag: 'Guardrails' },
+    { label: 'Clarity', value: 90, detail: 'Persona preview stays readable.', tag: 'Narrator' },
+    { label: 'Immersion', value: 94, detail: 'In-repo video + neon overlays.', tag: 'Holo mode' }
+  ]
+
+  const canvasWidgets = [
+    {
+      title: 'Signal Halo',
+      description: 'Animated background ribbons to keep the workstation alive.',
+      accent: '#7bffc0'
+    },
+    {
+      title: 'Widget Shelf',
+      description: 'Cards for persona tuning, pipelines, and Jr cues.',
+      accent: '#00f0ff'
+    },
+    {
+      title: 'Flow Lines',
+      description: 'Edges between actions keep the mental map intact.',
+      accent: '#ff00ff'
+    }
+  ]
+
+  const motionTracks = [
+    {
+      name: 'Tron Bloom',
+      description: 'Adds soft neon gradients behind every card.',
+      benefit: 'Keeps contrast without losing readability.'
+    },
+    {
+      name: 'Vector Drift',
+      description: 'Slow parallax ribbons to imply depth.',
+      benefit: 'Feels like a cockpit instead of static grid.'
+    },
+    {
+      name: 'Pulse Trails',
+      description: 'Chip interactions leave a brief glow trace.',
+      benefit: 'Gives motion feedback for keyboard users.'
+    }
+  ]
+
+  const quickActions: QuickAction[] = [
+    {
+      title: 'Drive-Through Summary',
+      prompt: 'Give me a 90-second tour of DevTeam6 with the latest highlights.',
+      tone: 'Concise, energetic, and optimistic.'
+    },
+    {
+      title: 'Bug Patrol',
+      prompt: 'Scan the repo for likely breakpoints or 404 risks in navigation.',
+      tone: 'Direct, technical, with a short fix-it list.'
+    },
+    {
+      title: 'Creator Mode',
+      prompt: 'Draft a new interactive panel idea that keeps visitors inside the repo.',
+      tone: 'Inventive, UI-minded, includes accessibility notes.'
+    },
+    {
+      title: 'Security Sweep',
+      prompt: 'List top 5 hardening steps for DevTeam6 (no secrets, least privilege).',
+      tone: 'Paranoid but practical.'
+    }
+  ]
+
+  const jrActions = [
+    'List today’s 3 fastest code wins.',
+    'Open the Knowledge Hub and summarize the densest section.',
+    'Compare Repomind and Repomind Jr behaviors.',
+    'Generate a to-do list for the next deploy.',
+    'Count links in the header to verify no 404s.'
+  ]
+
+  const pipelines = [
+    {
+      title: 'Instant Repo Scan',
+      description: 'Greps routes, checks header links, surfaces potential 404s.',
+      steps: ['Collect routes from main.tsx', 'Cross-check header anchors', 'Flag missing paths + suggest fixes']
+    },
+    {
+      title: 'DX Lightning',
+      description: 'Prepares a three-line DX pitch with visual hotspots.',
+      steps: ['Map top experiences', 'Pull quick wins from Jr queue', 'Draft CTA with internal links']
+    },
+    {
+      title: 'Safety Sweep',
+      description: 'Runs paranoia mode with least-privilege reminders.',
+      steps: ['Scan for secrets patterns (none in repo)', 'Highlight offline/local behavior', 'List safe defaults to keep']
+    }
+  ]
+
+  const personaPreview = composePersonaPrompt(
+    selectedAction?.prompt ?? 'Welcome inside the workstation — what should we optimize first?',
+    selectedTone,
+    selectedFocus
+  )
+
+  const toggleAgent = (name: string) => {
+    setAgents((current) =>
+      current.map((agent) =>
+        agent.name === name ? { ...agent, status: agent.status === 'online' ? 'standby' : 'online' } : agent
+      )
+    )
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'radial-gradient(circle at 10% 10%, rgba(0,255,255,0.12), transparent 30%), radial-gradient(circle at 90% 20%, rgba(255,0,255,0.12), transparent 32%), linear-gradient(135deg, #050510 0%, #0c0c1c 50%, #120826 100%)',
+        color: '#e8f9ff',
+        padding: '24px',
+        fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+        position: 'relative',
+        overflow: 'hidden'
+      }}
+    >
+      <div className="repomind-ribbon repomind-ribbon--left" aria-hidden />
+      <div className="repomind-ribbon repomind-ribbon--right" aria-hidden />
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'center', marginBottom: '20px' }}>
+        <div>
+          <p style={{ margin: 0, color: '#00f0ff', letterSpacing: '0.08em', fontWeight: 700 }}>OMEGA TOOL KIT</p>
+          <h1 style={{ margin: '6px 0', fontSize: '32px', color: '#ffffff' }}>Repomind Digital Workstation</h1>
+          <p style={{ margin: 0, color: '#9ddff6' }}>
+            Talk to the repo without leaving it. Persona-rich AI copilots, drive-through prompts, and a reliable in-page YouTube player.
+          </p>
+        </div>
+        <Link
+          to="/"
+          style={{
+            color: '#00f0ff',
+            textDecoration: 'none',
+            border: '1px solid rgba(0,255,255,0.4)',
+            padding: '10px 14px',
+            borderRadius: '12px',
+            background: 'rgba(0,255,255,0.08)',
+            fontWeight: 700,
+            boxShadow: '0 10px 30px rgba(0,0,0,0.35)'
+          }}
+          aria-label="Back to 3D experience"
+        >
+          ← Back to 3D Experience
+        </Link>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '12px', marginBottom: '16px' }}>
+        {highlightStats.map((stat) => {
+          const tone = getPulseTone(stat.value)
+          return (
+            <div
+              key={stat.label}
+              style={{
+                padding: '12px',
+                borderRadius: '14px',
+                border: '1px solid rgba(0,255,255,0.25)',
+                background: `linear-gradient(135deg, rgba(0,255,255,0.08), rgba(255,0,255,0.06)), radial-gradient(circle at 80% 20%, ${tone.color}, transparent 55%)`,
+                boxShadow: tone.border,
+                position: 'relative',
+                overflow: 'hidden'
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
+                <div style={{ fontWeight: 800, color: '#ffffff' }}>{stat.label}</div>
+                <span style={{ color: '#7bffc0', fontWeight: 700 }}>{stat.value}%</span>
+              </div>
+              <div style={{ color: '#b8e4ff', fontSize: '13px', lineHeight: 1.4 }}>{stat.detail}</div>
+              <div
+                style={{
+                  marginTop: '8px',
+                  fontSize: '12px',
+                  color: '#0a0a0a',
+                  fontWeight: 800,
+                  background: '#00f0ff',
+                  display: 'inline-flex',
+                  padding: '4px 8px',
+                  borderRadius: '999px',
+                  boxShadow: tone.border
+                }}
+              >
+                {stat.tag}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.1fr 0.9fr', gap: '14px', marginBottom: '16px' }}>
+        <div
+          style={{
+            border: '1px solid rgba(0, 240, 255, 0.18)',
+            borderRadius: '16px',
+            padding: '14px',
+            background: 'rgba(0,0,0,0.35)',
+            boxShadow: '0 16px 40px rgba(0,0,0,0.35)'
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+            <div>
+              <p style={{ margin: 0, color: '#00f0ff', fontWeight: 700, letterSpacing: '0.05em' }}>CANVAS</p>
+              <h3 style={{ margin: '4px 0', color: '#ffffff' }}>UX Motion Lab</h3>
+            </div>
+            <span style={{ color: '#9ddff6', fontSize: '13px' }}>Animations stay offline + responsive.</span>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '10px' }}>
+            {motionTracks.map((track) => (
+              <div
+                key={track.name}
+                style={{
+                  padding: '12px',
+                  borderRadius: '12px',
+                  border: '1px solid rgba(0,255,255,0.2)',
+                  background: 'rgba(0,0,0,0.4)',
+                  boxShadow: '0 12px 28px rgba(0,0,0,0.28)'
+                }}
+              >
+                <div style={{ fontWeight: 800, color: '#00f0ff' }}>{track.name}</div>
+                <div style={{ color: '#b8e4ff', fontSize: '13px', marginTop: '4px' }}>{track.description}</div>
+                <div style={{ color: '#7bffc0', fontSize: '12px', marginTop: '6px', fontWeight: 700 }}>Benefit: {track.benefit}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div
+          style={{
+            border: '1px solid rgba(255, 0, 255, 0.2)',
+            borderRadius: '16px',
+            padding: '14px',
+            background: 'rgba(15, 3, 25, 0.55)',
+            boxShadow: '0 16px 40px rgba(0,0,0,0.35)'
+          }}
+        >
+          <p style={{ margin: 0, color: '#ff00ff', fontWeight: 700, letterSpacing: '0.05em' }}>LAYOUT</p>
+          <h3 style={{ margin: '4px 0', color: '#ffffff' }}>Widget Shelf</h3>
+          <div style={{ display: 'grid', gap: '10px' }}>
+            {canvasWidgets.map((widget) => (
+              <div
+                key={widget.title}
+                style={{
+                  padding: '12px',
+                  borderRadius: '12px',
+                  border: `1px solid ${widget.accent}55`,
+                  background: 'rgba(0,0,0,0.45)',
+                  boxShadow: '0 10px 24px rgba(0,0,0,0.28)'
+                }}
+              >
+                <div style={{ fontWeight: 800, color: widget.accent }}>{widget.title}</div>
+                <div style={{ color: '#e8d6ff', fontSize: '13px', marginTop: '4px' }}>{widget.description}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.3fr 0.7fr', gap: '16px', marginBottom: '18px' }}>
+        <div
+          style={{
+            border: '1px solid rgba(0, 240, 255, 0.25)',
+            borderRadius: '18px',
+            padding: '16px',
+            background: 'rgba(6, 14, 34, 0.65)',
+            boxShadow: '0 18px 46px rgba(0,0,0,0.4)'
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px', marginBottom: '10px' }}>
+            <div>
+              <p style={{ margin: 0, color: '#7bffc0', fontWeight: 800, letterSpacing: '0.05em' }}>MCP OPS</p>
+              <h2 style={{ margin: '4px 0 0', color: '#ffffff' }}>Control Center</h2>
+              <p style={{ margin: '4px 0', color: '#9ddff6' }}>Flip agents on/off and pick a pipeline to run locally.</p>
+            </div>
+            <div style={{ color: '#c5f3ff', fontSize: '13px', textAlign: 'right' }}>
+              <div>All offline • zero secrets</div>
+              <div>Key focus: 404 immunity + DX speed</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '10px' }}>
+            {agents.map((agent) => (
+              <button
+                key={agent.name}
+                onClick={() => toggleAgent(agent.name)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    toggleAgent(agent.name)
+                  }
+                }}
+                style={{
+                  textAlign: 'left',
+                  border: '1px solid rgba(0,255,255,0.25)',
+                  borderRadius: '12px',
+                  padding: '12px',
+                  background: agent.status === 'online' ? 'rgba(0,255,136,0.12)' : 'rgba(255,0,255,0.08)',
+                  color: '#e8f9ff',
+                  cursor: 'pointer',
+                  boxShadow: '0 12px 28px rgba(0,0,0,0.32)'
+                }}
+                aria-label={`Toggle ${agent.name} ${agent.status === 'online' ? 'to standby' : 'online'}`}
+                tabIndex={0}
+              >
+                <div style={{ fontWeight: 800, color: '#00f0ff', marginBottom: '4px' }}>{agent.name}</div>
+                <div style={{ fontSize: '13px', color: '#b8e4ff' }}>{agent.role}</div>
+                <div style={{ fontSize: '12px', color: '#7bffc0', marginTop: '6px' }}>Mode: {agent.mode}</div>
+                <div style={{ fontSize: '12px', marginTop: '6px', color: agent.status === 'online' ? '#7bffc0' : '#ffcc00' }}>
+                  Status: {formatStatus(agent.status)} (tap to toggle)
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div
+          style={{
+            border: '1px solid rgba(255, 0, 255, 0.25)',
+            borderRadius: '18px',
+            padding: '16px',
+            background: 'rgba(21, 8, 33, 0.7)',
+            boxShadow: '0 18px 46px rgba(0,0,0,0.4)'
+          }}
+        >
+          <p style={{ margin: 0, color: '#ff00ff', fontWeight: 800, letterSpacing: '0.05em' }}>PIPELINES</p>
+          <h3 style={{ margin: '4px 0', color: '#ffffff' }}>Fast-Code-Drive-Through</h3>
+          <p style={{ margin: '2px 0 10px', color: '#d9b8ff', fontSize: '14px' }}>Pick a lane to guide Repomind replies.</p>
+          <div style={{ display: 'grid', gap: '10px' }}>
+            {pipelines.map((pipeline) => (
+              <button
+                key={pipeline.title}
+                onClick={() => setSelectedPipeline(pipeline.title)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    setSelectedPipeline(pipeline.title)
+                  }
+                }}
+                style={{
+                  textAlign: 'left',
+                  border: '1px solid rgba(255,0,255,0.25)',
+                  borderRadius: '12px',
+                  padding: '12px',
+                  background: selectedPipeline === pipeline.title ? 'rgba(255,0,255,0.14)' : 'rgba(0,0,0,0.45)',
+                  color: '#f5d8ff',
+                  cursor: 'pointer',
+                  boxShadow: '0 12px 28px rgba(0,0,0,0.32)'
+                }}
+                aria-label={`Select pipeline ${pipeline.title}`}
+                tabIndex={0}
+              >
+                <div style={{ fontWeight: 800, color: '#ffccff', marginBottom: '4px' }}>{pipeline.title}</div>
+                <div style={{ fontSize: '13px', color: '#e8c8ff' }}>{pipeline.description}</div>
+                <ul style={{ margin: '8px 0 0', paddingLeft: '16px', color: '#f5d8ff', lineHeight: 1.4 }}>
+                  {pipeline.steps.map((step) => (
+                    <li key={step} style={{ fontSize: '12px' }}>
+                      {step}
+                    </li>
+                  ))}
+                </ul>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 0.8fr', gap: '18px', marginBottom: '18px' }}>
+        <div
+          style={{
+            border: '1px solid rgba(0, 255, 255, 0.18)',
+            borderRadius: '18px',
+            padding: '18px',
+            background: 'rgba(0,0,0,0.35)',
+            boxShadow: '0 20px 60px rgba(0,0,0,0.45)'
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '12px' }}>
+            <div>
+              <p style={{ margin: 0, color: '#ff00ff', fontWeight: 700, letterSpacing: '0.05em' }}>DRIVE-THROUGH</p>
+              <h2 style={{ margin: '4px 0 0', color: '#ffffff' }}>Talk to Repomind</h2>
+            </div>
+            <div style={{ textAlign: 'right', color: '#9ddff6', fontSize: '14px' }}>
+              <div>Persona: "Fast-Code-Drive-Through"</div>
+              <div>Behavior: Quick, vivid, helpful.</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '12px' }}>
+            {quickActions.map((action) => (
+              <button
+                key={action.title}
+                onClick={() => setSelectedAction(action)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    setSelectedAction(action)
+                  }
+                }}
+                style={{
+                  textAlign: 'left',
+                  border: '1px solid rgba(0,255,255,0.35)',
+                  borderRadius: '12px',
+                  padding: '12px',
+                  background: selectedAction?.title === action.title ? 'rgba(0,255,136,0.12)' : 'rgba(0,0,0,0.4)',
+                  color: '#e8f9ff',
+                  cursor: 'pointer',
+                  boxShadow: '0 12px 28px rgba(0,0,0,0.3)'
+                }}
+                aria-label={`Select quick action ${action.title}`}
+                tabIndex={0}
+              >
+                <div style={{ fontWeight: 800, color: '#00f0ff', marginBottom: '6px' }}>{action.title}</div>
+                <div style={{ fontSize: '14px', color: '#b8e4ff' }}>{action.prompt}</div>
+                <div style={{ fontSize: '12px', color: '#7bffc0', marginTop: '8px' }}>{action.tone}</div>
+              </button>
+            ))}
+          </div>
+
+          <div
+            style={{
+              marginTop: '14px',
+              padding: '14px',
+              borderRadius: '12px',
+              border: '1px dashed rgba(0,255,255,0.25)',
+              background: 'rgba(0,0,0,0.55)',
+              color: '#c5f3ff'
+            }}
+            aria-live="polite"
+          >
+            {selectedAction ? (
+              <>
+                <div style={{ color: '#7b2fff', fontWeight: 800, marginBottom: '6px' }}>Queued Prompt</div>
+                <div style={{ fontWeight: 700 }}>{selectedAction.prompt}</div>
+                <div style={{ color: '#7bffc0', marginTop: '6px' }}>Tone: {selectedAction.tone}</div>
+                <div style={{ color: '#ffcc00', marginTop: '6px' }}>Pipeline: {selectedPipeline}</div>
+              </>
+            ) : (
+              <div>Pick a drive-through shortcut to prefill Repomind’s reply style.</div>
+            )}
+          </div>
+        </div>
+
+        <div
+          style={{
+            border: '1px solid rgba(255, 0, 255, 0.25)',
+            borderRadius: '18px',
+            padding: '16px',
+            background: 'rgba(10, 10, 26, 0.65)',
+            boxShadow: '0 20px 60px rgba(0,0,0,0.45)'
+          }}
+        >
+          <p style={{ margin: 0, color: '#ff00ff', fontWeight: 700, letterSpacing: '0.05em' }}>LIVE PLAYER</p>
+          <h2 style={{ margin: '4px 0 12px', color: '#ffffff' }}>YouTube in the Repo</h2>
+          <label htmlFor="video-url" style={{ display: 'block', color: '#9ddff6', marginBottom: '6px', fontSize: '14px' }}>
+            Paste a YouTube link or video ID to load it without leaving the workstation.
+          </label>
+          <input
+            id="video-url"
+            value={videoInput}
+            onChange={(e) => setVideoInput(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid rgba(0,255,255,0.3)',
+              background: 'rgba(0,0,0,0.35)',
+              color: '#e8f9ff',
+              marginBottom: '12px',
+              fontFamily: 'inherit'
+            }}
+            placeholder="https://www.youtube.com/watch?v=..."
+            aria-label="YouTube video URL input"
+          />
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '10px' }}>
+            {videoPresets.map((preset) => (
+              <button
+                key={preset.label}
+                onClick={() => setVideoInput(preset.url)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    setVideoInput(preset.url)
+                  }
+                }}
+                style={{
+                  border: '1px solid rgba(255,0,255,0.3)',
+                  borderRadius: '10px',
+                  padding: '8px 10px',
+                  background: videoInput === preset.url ? 'rgba(255,0,255,0.15)' : 'rgba(0,0,0,0.4)',
+                  color: '#f1d6ff',
+                  cursor: 'pointer'
+                }}
+                aria-label={`Load preset video ${preset.label}`}
+                tabIndex={0}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+          <YouTubePlayer videoUrl={videoInput} title="Repomind video player" />
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.1fr 0.9fr', gap: '16px', marginBottom: '18px' }}>
+        <div
+          style={{
+            border: '1px solid rgba(0, 255, 136, 0.25)',
+            borderRadius: '18px',
+            padding: '16px',
+            background: 'rgba(5, 26, 18, 0.6)',
+            boxShadow: '0 18px 46px rgba(0,0,0,0.4)'
+          }}
+        >
+          <p style={{ margin: 0, color: '#00ff88', fontWeight: 800, letterSpacing: '0.05em' }}>PERSONA BLENDER</p>
+          <h3 style={{ margin: '4px 0', color: '#ffffff' }}>Compose the perfect reply</h3>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '12px' }}>
+            <div>
+              <p style={{ margin: '0 0 6px', color: '#9ddff6', fontSize: '14px' }}>Tone options</p>
+              {['Playful mentor tone with concrete code refs.', 'Executive clarity with 3 bullets.', 'Ultra-concise changelog style.'].map(
+                (tone) => (
+                  <button
+                    key={tone}
+                    onClick={() => setSelectedTone(tone)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        setSelectedTone(tone)
+                      }
+                    }}
+                    style={{
+                      width: '100%',
+                      textAlign: 'left',
+                      border: '1px solid rgba(0,255,136,0.25)',
+                      borderRadius: '10px',
+                      padding: '10px',
+                      background: selectedTone === tone ? 'rgba(0,255,136,0.16)' : 'rgba(0,0,0,0.4)',
+                      color: '#d4ffed',
+                      cursor: 'pointer',
+                      marginBottom: '8px'
+                    }}
+                    aria-label={`Select tone ${tone}`}
+                    tabIndex={0}
+                  >
+                    {tone}
+                  </button>
+                )
+              )}
+            </div>
+            <div>
+              <p style={{ margin: '0 0 6px', color: '#9ddff6', fontSize: '14px' }}>Focus options</p>
+              {['Focus on navigation safety + DX speed.', 'Highlight MCP pipelines + agents.', 'Call out visuals + accessibility.'].map(
+                (focus) => (
+                  <button
+                    key={focus}
+                    onClick={() => setSelectedFocus(focus)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        setSelectedFocus(focus)
+                      }
+                    }}
+                    style={{
+                      width: '100%',
+                      textAlign: 'left',
+                      border: '1px solid rgba(0,255,136,0.25)',
+                      borderRadius: '10px',
+                      padding: '10px',
+                      background: selectedFocus === focus ? 'rgba(0,255,136,0.16)' : 'rgba(0,0,0,0.4)',
+                      color: '#d4ffed',
+                      cursor: 'pointer',
+                      marginBottom: '8px'
+                    }}
+                    aria-label={`Select focus ${focus}`}
+                    tabIndex={0}
+                  >
+                    {focus}
+                  </button>
+                )
+              )}
+            </div>
+          </div>
+          <div
+            style={{
+              marginTop: '10px',
+              padding: '12px',
+              borderRadius: '12px',
+              border: '1px dashed rgba(0,255,136,0.25)',
+              background: 'rgba(0,0,0,0.55)',
+              color: '#d4ffed'
+            }}
+          >
+            <div style={{ fontWeight: 800, color: '#00ff88', marginBottom: '6px' }}>Persona preview</div>
+            <div style={{ lineHeight: 1.5 }}>{personaPreview}</div>
+            <div style={{ marginTop: '6px', fontSize: '12px', color: '#7bffc0' }}>Powered by: {selectedPipeline}</div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            border: '1px solid rgba(0, 240, 255, 0.25)',
+            borderRadius: '18px',
+            padding: '16px',
+            background: 'rgba(5, 18, 32, 0.6)',
+            boxShadow: '0 18px 46px rgba(0,0,0,0.4)'
+          }}
+        >
+          <p style={{ margin: 0, color: '#00f0ff', fontWeight: 800, letterSpacing: '0.05em' }}>OPS DIGEST</p>
+          <h3 style={{ margin: '4px 0', color: '#ffffff' }}>What Repomind will do next</h3>
+          <ul style={{ margin: '0 0 10px', paddingLeft: '18px', color: '#c5f3ff', lineHeight: 1.5 }}>
+            <li>Route map anchored by: {selectedPipeline}</li>
+            <li>Persona tone: {selectedTone}</li>
+            <li>Focus: {selectedFocus}</li>
+          </ul>
+          <div
+            style={{
+              border: '1px solid rgba(0,240,255,0.25)',
+              borderRadius: '12px',
+              padding: '10px',
+              background: 'rgba(0,0,0,0.45)',
+              color: '#d4e8ff'
+            }}
+          >
+            <div style={{ fontWeight: 800, marginBottom: '6px', color: '#00f0ff' }}>Repomind Jr Fastlane</div>
+            <div style={{ fontSize: '14px' }}>Use Jr cards to queue micro-tasks, then blend with the persona preview to keep responses short.</div>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 0.8fr', gap: '18px' }}>
+        <div
+          style={{
+            border: '1px solid rgba(0, 255, 136, 0.25)',
+            borderRadius: '18px',
+            padding: '16px',
+            background: 'rgba(0, 20, 12, 0.6)'
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+            <div>
+              <p style={{ margin: 0, color: '#00ff88', fontWeight: 800, letterSpacing: '0.05em' }}>REPOMIND JR</p>
+              <h3 style={{ margin: '4px 0', color: '#ffffff' }}>Blazing-fast shortcuts</h3>
+            </div>
+            <span style={{ color: '#7bffc0', fontWeight: 700 }}>Lightweight persona</span>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '10px' }}>
+            {jrActions.map((action) => (
+              <div
+                key={action}
+                style={{
+                  padding: '12px',
+                  borderRadius: '12px',
+                  background: 'rgba(0,0,0,0.5)',
+                  border: '1px solid rgba(0,255,136,0.25)',
+                  color: '#d4ffed',
+                  fontWeight: 600,
+                  boxShadow: '0 12px 24px rgba(0,0,0,0.25)'
+                }}
+              >
+                {action}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div
+          style={{
+            border: '1px solid rgba(255, 204, 0, 0.25)',
+            borderRadius: '18px',
+            padding: '16px',
+            background: 'rgba(25, 16, 0, 0.6)'
+          }}
+        >
+          <p style={{ margin: 0, color: '#ffcc00', fontWeight: 800, letterSpacing: '0.05em' }}>QA + SAFETY</p>
+          <h3 style={{ margin: '4px 0', color: '#ffffff' }}>Stay inside the repo</h3>
+          <ul style={{ margin: 0, paddingLeft: '18px', lineHeight: 1.5, color: '#ffe6a3' }}>
+            <li>Header links match live routes — no 404s or dead ends.</li>
+            <li>Embedded video runs in-page; no new tabs required.</li>
+            <li>Prompts are static and local; no network calls are made.</li>
+            <li>Accessibility: keyboard-friendly buttons and clear aria labels.</li>
+          </ul>
+          <div style={{ marginTop: '10px', color: '#ffcc00', fontWeight: 700 }}>
+            Need more? Ping the Fast-Code-Drive-Through.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/utils/controlDeck.test.ts
+++ b/app/src/utils/controlDeck.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { getLoadStatus, sanitizeEmbedUrl } from './controlDeck'
+
+describe('sanitizeEmbedUrl', () => {
+  it('converts a watch URL into embed format', () => {
+    const url = sanitizeEmbedUrl('https://www.youtube.com/watch?v=abc123xyz99')
+    expect(url).toBe('https://www.youtube.com/embed/abc123xyz99?rel=0')
+  })
+
+  it('handles short URLs', () => {
+    const url = sanitizeEmbedUrl('https://youtu.be/abc123xyz99')
+    expect(url).toBe('https://www.youtube.com/embed/abc123xyz99?rel=0')
+  })
+
+  it('returns null for invalid host', () => {
+    const url = sanitizeEmbedUrl('https://example.com/video/123')
+    expect(url).toBeNull()
+  })
+})
+
+describe('getLoadStatus', () => {
+  it('returns calm tone for low load', () => {
+    const status = getLoadStatus(144, 0.2)
+    expect(status.label).toBe('Calm')
+    expect(status.tone).toBe('cool')
+  })
+
+  it('returns balanced tone for moderate load', () => {
+    const status = getLoadStatus(120, 0.5)
+    expect(status.label).toBe('Stable')
+    expect(status.tone).toBe('balanced')
+  })
+
+  it('clamps high load and marks as strained', () => {
+    const status = getLoadStatus(60, 1.4)
+    expect(status.label).toBe('Strained')
+    expect(status.description.includes('100%')).toBe(true)
+    expect(status.tone).toBe('warm')
+  })
+})
+

--- a/app/src/utils/controlDeck.ts
+++ b/app/src/utils/controlDeck.ts
@@ -1,0 +1,39 @@
+import { extractYouTubeId } from './youtube'
+
+/**
+ * Sanitize and normalize embed URLs for the Control Deck video hub.
+ * Only allows YouTube hosts and returns a safe embed URL.
+ */
+export function sanitizeEmbedUrl(url: string): string | null {
+  const id = extractYouTubeId(url)
+  if (!id) return null
+  return `https://www.youtube.com/embed/${id}?rel=0`
+}
+
+/**
+ * Derive a friendly load status for the workstation HUD.
+ * Clamps load between 0 and 1 to avoid invalid percentages.
+ */
+export function getLoadStatus(fps: number, load: number) {
+  const normalizedLoad = Math.min(Math.max(load, 0), 1)
+  if (normalizedLoad < 0.35) {
+    return {
+      label: 'Calm',
+      description: `${fps} fps • ${Math.round(normalizedLoad * 100)}% glow load`,
+      tone: 'cool'
+    }
+  }
+  if (normalizedLoad < 0.7) {
+    return {
+      label: 'Stable',
+      description: `${fps} fps • ${Math.round(normalizedLoad * 100)}% glow load`,
+      tone: 'balanced'
+    }
+  }
+  return {
+    label: 'Strained',
+    description: `${fps} fps • ${Math.round(normalizedLoad * 100)}% glow load`,
+    tone: 'warm'
+  }
+}
+

--- a/app/src/utils/graph.test.ts
+++ b/app/src/utils/graph.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { computeClusterBounds, computeShortestPath, filterNodesByCluster, GraphEdge, GraphNode } from './graph'
+
+describe('graph utilities', () => {
+  const sampleNodes: GraphNode[] = [
+    { id: 'a', position: { x: 100, y: 200 }, cluster: 'core' },
+    { id: 'b', position: { x: 150, y: 250 }, cluster: 'core' },
+    { id: 'c', position: { x: 300, y: 400 }, cluster: 'automation' },
+  ]
+
+  it('computes padded bounds for a cluster', () => {
+    const bounds = computeClusterBounds(sampleNodes, 'core', 20)
+    expect(bounds).toMatchObject({
+      minX: 80,
+      maxX: 170,
+      minY: 180,
+      maxY: 270,
+      clusterId: 'core'
+    })
+    expect(bounds?.width).toBeCloseTo(90)
+    expect(bounds?.centerX).toBeCloseTo(125)
+  })
+
+  it('returns null when no nodes exist for cluster', () => {
+    expect(computeClusterBounds(sampleNodes, 'ghost')).toBeNull()
+  })
+
+  it('filters nodes by cluster while preserving order', () => {
+    const filtered = filterNodesByCluster(sampleNodes, 'core')
+    expect(filtered.map(n => n.id)).toEqual(['a', 'b'])
+  })
+
+  it('passes through all nodes when cluster is all', () => {
+    expect(filterNodesByCluster(sampleNodes, 'all')).toHaveLength(sampleNodes.length)
+  })
+
+  it('finds shortest directed path when reachable', () => {
+    const edges: GraphEdge[] = [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'a', to: 'c' }
+    ]
+
+    expect(computeShortestPath(edges, 'a', 'c')).toEqual(['a', 'c'])
+  })
+
+  it('returns empty path when unreachable', () => {
+    const edges: GraphEdge[] = [
+      { from: 'a', to: 'b' },
+      { from: 'c', to: 'd' }
+    ]
+
+    expect(computeShortestPath(edges, 'a', 'd')).toEqual([])
+  })
+
+  it('returns singleton path when start equals target', () => {
+    expect(computeShortestPath([], 'solo', 'solo')).toEqual(['solo'])
+  })
+})

--- a/app/src/utils/graph.ts
+++ b/app/src/utils/graph.ts
@@ -1,0 +1,100 @@
+export interface GraphPoint {
+  x: number
+  y: number
+}
+
+export interface GraphNode {
+  id: string
+  position: GraphPoint
+  cluster?: string
+}
+
+export interface GraphEdge {
+  from: string
+  to: string
+}
+
+export interface ClusterBounds {
+  clusterId: string
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  width: number
+  height: number
+  centerX: number
+  centerY: number
+}
+
+/**
+ * Compute padded bounding boxes for nodes in a cluster. Returns null when no nodes are present.
+ */
+export const computeClusterBounds = (
+  nodes: GraphNode[],
+  clusterId: string,
+  padding = 48
+): ClusterBounds | null => {
+  const scopedNodes = nodes.filter(node => node.cluster === clusterId)
+  if (scopedNodes.length === 0) return null
+
+  const xs = scopedNodes.map(node => node.position.x)
+  const ys = scopedNodes.map(node => node.position.y)
+
+  const minX = Math.min(...xs) - padding
+  const maxX = Math.max(...xs) + padding
+  const minY = Math.min(...ys) - padding
+  const maxY = Math.max(...ys) + padding
+
+  const width = maxX - minX
+  const height = maxY - minY
+  const centerX = minX + width / 2
+  const centerY = minY + height / 2
+
+  return { clusterId, minX, maxX, minY, maxY, width, height, centerX, centerY }
+}
+
+/**
+ * Filter nodes by cluster while preserving the original order for stable rendering.
+ */
+export const filterNodesByCluster = (nodes: GraphNode[], clusterId: string): GraphNode[] => {
+  if (clusterId === 'all') return nodes
+  return nodes.filter(node => node.cluster === clusterId)
+}
+
+/**
+ * Compute a shortest directed path between two node ids using BFS.
+ * Returns an ordered list of node ids including start and target, or [] when unreachable.
+ */
+export const computeShortestPath = (
+  edges: GraphEdge[],
+  startId: string,
+  targetId: string
+): string[] => {
+  if (!startId || !targetId) return []
+  if (startId === targetId) return [startId]
+
+  const adjacency = new Map<string, string[]>()
+
+  edges.forEach(({ from, to }) => {
+    if (!adjacency.has(from)) adjacency.set(from, [])
+    adjacency.get(from)!.push(to)
+  })
+
+  const visited = new Set<string>([startId])
+  const queue: Array<{ node: string; path: string[] }> = [{ node: startId, path: [startId] }]
+
+  while (queue.length > 0) {
+    const { node, path } = queue.shift() as { node: string; path: string[] }
+    const neighbors = adjacency.get(node) || []
+
+    for (const neighbor of neighbors) {
+      if (visited.has(neighbor)) continue
+      const nextPath = [...path, neighbor]
+      if (neighbor === targetId) return nextPath
+      visited.add(neighbor)
+      queue.push({ node: neighbor, path: nextPath })
+    }
+  }
+
+  return []
+}

--- a/app/src/utils/repomind.test.ts
+++ b/app/src/utils/repomind.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { composePersonaPrompt, formatStatus } from './repomind'
+
+describe('composePersonaPrompt', () => {
+  it('joins non-empty segments with separator', () => {
+    expect(composePersonaPrompt('Base', 'Tone', 'Focus')).toBe('Base — Tone — Focus')
+  })
+
+  it('trims whitespace and skips blanks', () => {
+    expect(composePersonaPrompt('  Hello ', ' ', 'Depth ')).toBe('Hello — Depth')
+  })
+
+  it('returns empty string when all parts are blank', () => {
+    expect(composePersonaPrompt(' ', '   ', '')).toBe('')
+  })
+})
+
+describe('formatStatus', () => {
+  it('capitalizes and lowercases correctly', () => {
+    expect(formatStatus('ONLiNe')).toBe('Online')
+  })
+
+  it('handles empty strings', () => {
+    expect(formatStatus('   ')).toBe('Unknown')
+  })
+})

--- a/app/src/utils/repomind.ts
+++ b/app/src/utils/repomind.ts
@@ -1,0 +1,20 @@
+/**
+ * Compose a persona-aware prompt for Repomind and Repomind Jr.
+ * Ensures clean spacing and trims blank segments while preserving tone/focus.
+ */
+export function composePersonaPrompt(base: string, tone: string, focus: string): string {
+  const parts = [base, tone, focus].map((part) => part.trim()).filter(Boolean)
+  if (parts.length === 0) {
+    return ''
+  }
+  return parts.join(' — ')
+}
+
+/**
+ * Normalize a status label for display chips.
+ */
+export function formatStatus(status: string): string {
+  const cleaned = status.trim()
+  if (!cleaned) return 'Unknown'
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1).toLowerCase()
+}

--- a/app/src/utils/visuals.test.ts
+++ b/app/src/utils/visuals.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { calculateGlowStrength, getPulseTone } from './visuals'
+
+describe('visuals utils', () => {
+  it('clamps glow strength within bounds', () => {
+    expect(calculateGlowStrength(120, 100)).toEqual({ intensity: 1, hue: 180, alpha: 0.7 })
+    expect(calculateGlowStrength(-5, 80)).toEqual({ intensity: 0, hue: 300, alpha: 0.35 })
+  })
+
+  it('rejects non-positive max values', () => {
+    expect(() => calculateGlowStrength(10, 0)).toThrowError('max must be greater than 0')
+  })
+
+  it('returns pulse-friendly tones', () => {
+    const pulse = getPulseTone(75, 100)
+    expect(pulse.intensity).toBeCloseTo(0.75)
+    expect(pulse.color).toContain('hsla(')
+    expect(pulse.border).toContain('rgba(0, 255, 255')
+  })
+})

--- a/app/src/utils/visuals.ts
+++ b/app/src/utils/visuals.ts
@@ -1,0 +1,27 @@
+/**
+ * Calculates a normalized glow strength for UI meters and cards.
+ * Values are clamped to avoid negative intensities and to keep gradients stable.
+ */
+export function calculateGlowStrength(value: number, max: number = 100) {
+  if (max <= 0) {
+    throw new Error('max must be greater than 0')
+  }
+
+  const clamped = Math.min(Math.max(value, 0), max)
+  const intensity = clamped / max
+  const hue = 180 + (1 - intensity) * 120 // Cyan (high) → Magenta (low)
+  const alpha = 0.35 + intensity * 0.35
+
+  return { intensity, hue, alpha }
+}
+
+/**
+ * Builds CSS-friendly color tokens for pulse-driven UI elements.
+ */
+export function getPulseTone(value: number, max: number = 100) {
+  const { intensity, hue, alpha } = calculateGlowStrength(value, max)
+  const color = `hsla(${hue}, 90%, ${30 + intensity * 40}%, ${alpha})`
+  const border = `0 0 ${12 + intensity * 18}px rgba(0, 255, 255, ${0.35 + intensity * 0.3})`
+
+  return { color, border, alpha, intensity }
+}

--- a/app/src/utils/youtube.test.ts
+++ b/app/src/utils/youtube.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { extractYouTubeId } from './youtube'
+
+describe('extractYouTubeId', () => {
+  it('returns null for empty input', () => {
+    expect(extractYouTubeId('')).toBeNull()
+  })
+
+  it('supports direct IDs', () => {
+    expect(extractYouTubeId('dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('parses standard watch URLs', () => {
+    expect(extractYouTubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('parses short links', () => {
+    expect(extractYouTubeId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('parses shorts URLs', () => {
+    expect(extractYouTubeId('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('parses embed URLs', () => {
+    expect(extractYouTubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('returns null for invalid inputs', () => {
+    expect(extractYouTubeId('not a url')).toBeNull()
+    expect(extractYouTubeId('https://example.com/watch?v=dQw4w9WgXcQ')).toBeNull()
+  })
+})

--- a/app/src/utils/youtube.ts
+++ b/app/src/utils/youtube.ts
@@ -1,0 +1,45 @@
+export function extractYouTubeId(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  // Direct 11-char ID support
+  const directIdMatch = /^[a-zA-Z0-9_-]{11}$/.test(trimmed)
+  if (directIdMatch) return trimmed
+
+  let parsed: URL
+  try {
+    parsed = trimmed.startsWith('http') ? new URL(trimmed) : new URL(`https://${trimmed}`)
+  } catch (error) {
+    return null
+  }
+
+  const hostname = parsed.hostname.replace(/^www\./, '')
+  const allowedHosts = ['youtube.com', 'm.youtube.com', 'youtu.be']
+  if (!allowedHosts.includes(hostname)) {
+    return null
+  }
+
+  const searchId = parsed.searchParams.get('v')
+  if (searchId && /^[a-zA-Z0-9_-]{11}$/.test(searchId)) {
+    return searchId
+  }
+
+  const pathSegments = parsed.pathname.split('/').filter(Boolean)
+  const possibleId = pathSegments[pathSegments.length - 1]
+
+  if (hostname === 'youtu.be' && /^[a-zA-Z0-9_-]{11}$/.test(possibleId)) {
+    return possibleId
+  }
+
+  const embedHosts = ['youtube.com', 'm.youtube.com']
+  if (embedHosts.includes(hostname)) {
+    if (parsed.pathname.startsWith('/embed/') && /^[a-zA-Z0-9_-]{11}$/.test(possibleId)) {
+      return possibleId
+    }
+    if (parsed.pathname.startsWith('/shorts/') && /^[a-zA-Z0-9_-]{11}$/.test(possibleId)) {
+      return possibleId
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- extend the Control Deck with mission briefings, status HUD, and a new UX Motion Lab panel
- add glow load status helper and tests to keep HUD tones predictable

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f8db739cc8332bd9901db268aa34f)

## Summary by Sourcery

Introduce a Repomind digital workstation and Control Deck HUD, while upgrading the node graph editor with presets, clustering, and a path-finding playbook.

New Features:
- Add a Repomind in-repo digital workstation page with persona controls, UX Motion Lab widgets, pipelines, and an embedded YouTube player.
- Add a Control Deck page providing a static digital workstation with docked panels, mission briefings, status HUD, command palette, and UX Motion Lab section.
- Extend the node graph editor with preset mind map and automation layouts, cluster-aware views, and a path playbook that highlights shortest routes between nodes.

Enhancements:
- Refine the node graph editor UI with selectable backgrounds, cluster halos, path-focused node/edge highlighting, enhanced stats, and a richer side panel experience.
- Add utility modules for graph clustering and path computation, YouTube URL/ID parsing and sanitization, glow/pulse visual tone calculations, and persona prompt/status formatting.
- Wire new Repomind and Control Deck routes and keyboard shortcuts into the app navigation and landing page CTAs.

Documentation:
- Update README badges and feature table to document the new Repomind Workstation, Control Deck, and expanded Node Graph Editor capabilities.

Tests:
- Introduce unit tests for the new control deck load status helper, graph utilities, Repomind helpers, visuals tone calculations, and YouTube URL parsing/sanitization.